### PR TITLE
feat(profile): Phase 1 완료 - 기초 공사, 레이아웃 및 역량 시각화

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+import ProfileHeader from '@/components/profile/ProfileHeader';
+
+interface MyApplication {
+    _id: string;
+    projectId: {
+        title: string;
+        pid: number;
+    };
+    role: string;
+    status: 'pending' | 'accepted' | 'rejected';
+}
+
+export default function MyPage() {
+    const { data: session, status } = useSession();
+    const router = useRouter();
+    const [myApplications, setMyApplications] = useState<MyApplication[]>([]);
+
+    const fetchMyApplications = useCallback(async () => {
+        try {
+            const response = await fetch('/api/applications');
+            const data = await response.json();
+            if (data.success) {
+                setMyApplications(data.data);
+            } else {
+                console.error(data.message);
+            }
+        } catch (error) {
+            console.error('지원 내역을 불러오는 중 오류 발생', error);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (status === 'unauthenticated') {
+            router.push('/login');
+        }
+        if (status === 'authenticated') {
+            fetchMyApplications();
+        }
+    }, [status, router, fetchMyApplications]);
+
+    const handleCancelApplication = async (appId: string) => {
+        if (confirm('정말 지원을 취소하시겠습니까?')) {
+            try {
+                const response = await fetch(`/api/applications/${appId}`, { method: 'DELETE' });
+                const data = await response.json();
+                if (data.success) {
+                    alert('지원서가 삭제되었습니다.');
+                    fetchMyApplications(); // 목록 새로고침
+                } else {
+                    throw new Error(data.message);
+                }
+            } catch (err: any) {
+                alert(err.message);
+            }
+        }
+    };
+
+    if (status === 'loading' || !session) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <div className="text-lg">로딩 중...</div>
+            </div>
+        );
+    }
+
+    const user = session.user as any;
+
+    // 임시 데이터 (추후 DB 연동)
+    const userData = {
+        nName: user.name || '사용자',
+        email: user.email || '',
+        position: 'Frontend Developer',
+        career: '3년차',
+        introduction: '안녕하세요! 사이드 프로젝트를 찾고 있습니다.',
+        socialLinks: {
+            github: '',
+            blog: ''
+        }
+    };
+
+    return (
+        <div className="container mx-auto px-4 py-8 space-y-8">
+            {/* Profile Header Section */}
+            <section>
+                <ProfileHeader user={userData} />
+            </section>
+
+            <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 border border-gray-100 dark:border-gray-700">
+                <div className="flex justify-between items-center mb-6">
+                    <h2 className="text-xl font-bold text-gray-900 dark:text-white">내 지원 현황</h2>
+                    <button
+                        onClick={() => router.push(`/projects?authorId=${user._id}`)}
+                        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition-colors text-sm"
+                    >
+                        내 프로젝트 보기
+                    </button>
+                </div>
+
+                <div className="space-y-4">
+                    {myApplications.length > 0 ? (
+                        myApplications.map(app => (
+                            <div key={app._id} className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg flex justify-between items-center bg-white dark:bg-gray-800">
+                                <div>
+                                    {app.projectId ? (
+                                        <Link href={`/projects/${app.projectId.pid}`} className="font-semibold text-blue-600 dark:text-blue-400 hover:underline">
+                                            {app.projectId.title}
+                                        </Link>
+                                    ) : (
+                                        <span className="font-semibold text-gray-400">삭제된 프로젝트</span>
+                                    )}
+                                    <p className="text-sm text-gray-600 dark:text-gray-400">지원 역할: {app.role}</p>
+                                </div>
+                                <div className="flex items-center gap-4">
+                                    <span className={`px-3 py-1 text-xs font-semibold rounded-full ${app.status === 'accepted' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' :
+                                            app.status === 'rejected' ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' :
+                                                'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
+                                        }`}>
+                                        {app.status === 'pending' ? '대기중' : app.status === 'accepted' ? '수락됨' : '거절됨'}
+                                    </span>
+                                    {app.status === 'pending' && (
+                                        <button onClick={() => handleCancelApplication(app._id)} className="text-sm text-red-500 hover:underline">
+                                            지원 취소
+                                        </button>
+                                    )}
+                                </div>
+                            </div>
+                        ))
+                    ) : (
+                        <p className="text-gray-500 dark:text-gray-400">아직 지원한 프로젝트가 없습니다.</p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/tech/page.tsx
+++ b/src/app/tech/page.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import ProfileHeader from '@/components/profile/ProfileHeader';
+import StatusDashboard from '@/components/profile/StatusDashboard';
+
+export default function TechPage() {
+    const { data: session, status } = useSession();
+    const router = useRouter();
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        if (status === 'unauthenticated') {
+            router.push('/login');
+        } else if (status === 'authenticated') {
+            setIsLoading(false);
+        }
+    }, [status, router]);
+
+    if (status === 'loading' || isLoading) {
+        return <div className="p-8 text-center">로딩 중...</div>;
+    }
+
+    if (!session) {
+        return null;
+    }
+
+    // 임시 사용자 데이터 (추후 DB 연동)
+    const userData = {
+        nName: session.user?.name || '사용자',
+        email: session.user?.email || '',
+        position: 'Frontend Developer',
+        career: '3년차',
+        status: '구직중',
+        introduction: '안녕하세요! React와 Next.js를 좋아하는 개발자입니다. 사이드 프로젝트를 찾고 있어요.',
+        socialLinks: {
+            github: 'https://github.com',
+            blog: 'https://velog.io',
+        }
+    };
+
+    return (
+        <div className="container mx-auto px-4 py-8 space-y-6">
+            {/* Split-Header Section */}
+            <section className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                {/* Left: Profile Header (2/3 width on desktop) */}
+                <div className="md:col-span-2">
+                    <ProfileHeader user={userData} />
+                </div>
+
+                {/* Right: Status Dashboard (1/3 width on desktop) */}
+                <div className="md:col-span-1">
+                    <StatusDashboard status={userData.status} />
+                </div>
+            </section>
+
+            {/* 추후 Skill, Availability 섹션 추가 예정 */}
+            <section className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-700 min-h-[200px] flex items-center justify-center text-gray-400">
+                기술 스택 및 가용성 섹션 준비 중...
+            </section>
+        </div>
+    );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -67,7 +67,7 @@ export default function Header() {
     };
 
     const mainCategories = [
-        { label: '기술서', path: '/tech' },
+        { label: '프로필', path: '/profile' },
         { label: '프로젝트', path: '/projects' },
         { label: '대쉬보드', path: '/dashboard' },
     ];
@@ -159,7 +159,7 @@ export default function Header() {
                                     )}
                                 </div>
 
-                                <Link href="/profile" className="text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900">마이페이지</Link>
+                                <Link href="/mypage" className="text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900">마이페이지</Link>
                                 <button onClick={() => signOut({ callbackUrl: '/' })} className="text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900">로그아웃</button>
                             </>
                         ) : (

--- a/src/components/profile/ProfileHeader.tsx
+++ b/src/components/profile/ProfileHeader.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import Link from 'next/link';
+
+interface ProfileHeaderProps {
+    user: {
+        nName?: string;
+        email: string;
+        position?: string;
+        career?: string;
+        introduction?: string;
+        socialLinks?: {
+            github?: string;
+            blog?: string;
+            linkedin?: string;
+            other?: string;
+        };
+    };
+}
+
+export default function ProfileHeader({ user }: ProfileHeaderProps) {
+    return (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-700 h-full">
+            <div className="flex flex-col sm:flex-row items-start gap-6">
+                {/* 아바타 영역 */}
+                <div className="flex-shrink-0">
+                    <div className="w-24 h-24 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white text-3xl font-bold shadow-md">
+                        {user.nName ? user.nName.substring(0, 1).toUpperCase() : 'U'}
+                    </div>
+                </div>
+
+                {/* 정보 영역 */}
+                <div className="flex-grow space-y-3">
+                    <div>
+                        <div className="flex items-center gap-3 mb-1">
+                            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+                                {user.nName || '이름 없음'}
+                            </h1>
+                            {user.position && (
+                                <span className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 text-xs font-semibold rounded-full">
+                                    {user.position}
+                                </span>
+                            )}
+                        </div>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">{user.email}</p>
+                    </div>
+
+                    {user.introduction && (
+                        <p className="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">
+                            {user.introduction}
+                        </p>
+                    )}
+
+                    <div className="flex flex-wrap gap-2 pt-2">
+                        {user.career && (
+                            <span className="inline-flex items-center px-3 py-1 rounded-lg bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs font-medium">
+                                🏢 {user.career}
+                            </span>
+                        )}
+                        {/* 소셜 링크 아이콘들 (임시 텍스트 버튼) */}
+                        {user.socialLinks?.github && (
+                            <a href={user.socialLinks.github} target="_blank" rel="noopener noreferrer" className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors">
+                                GitHub
+                            </a>
+                        )}
+                        {user.socialLinks?.blog && (
+                            <a href={user.socialLinks.blog} target="_blank" rel="noopener noreferrer" className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors">
+                                Blog
+                            </a>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/profile/SkillSection.tsx
+++ b/src/components/profile/SkillSection.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import SkillTier from './SkillTier';
+
+// 임시 데이터 (추후 DB 연동)
+const mockSkills = [
+    { name: 'React', level: 'Pro', score: 95, active: true },
+    { name: 'Next.js', level: 'Pro', score: 92, active: true },
+    { name: 'TypeScript', level: 'Advanced', score: 85, active: true },
+    { name: 'Node.js', level: 'Advanced', score: 78, active: false },
+    { name: 'TailwindCSS', level: 'Advanced', score: 88, active: true },
+    { name: 'MongoDB', level: 'Intermediate', score: 65, active: false },
+    { name: 'PostgreSQL', level: 'Intermediate', score: 60, active: false },
+    { name: 'Docker', level: 'Beginner', score: 45, active: false },
+    { name: 'AWS', level: 'Beginner', score: 40, active: false },
+    { name: 'Figma', level: 'Beginner', score: 30, active: true },
+];
+
+export default function SkillSection() {
+    // 레벨별로 데이터 분류
+    const proSkills = mockSkills.filter(s => s.level === 'Pro');
+    const advancedSkills = mockSkills.filter(s => s.level === 'Advanced');
+    const intermediateSkills = mockSkills.filter(s => s.level === 'Intermediate');
+    const beginnerSkills = mockSkills.filter(s => s.level === 'Beginner');
+
+    return (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-700">
+            <div className="flex items-center justify-between mb-8">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+                    <span>🛠️</span> 기술 스택
+                </h2>
+                <div className="flex items-center gap-2 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700/50 px-3 py-1.5 rounded-full">
+                    <span className="relative flex h-2 w-2">
+                        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+                        <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+                    </span>
+                    <span>Recent Activity (6mo)</span>
+                </div>
+            </div>
+
+            <div className="space-y-2">
+                <SkillTier tierName="Pro" skills={proSkills} />
+                <SkillTier tierName="Advanced" skills={advancedSkills} />
+
+                <div className="pt-4 border-t border-gray-100 dark:border-gray-700 grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <SkillTier tierName="Intermediate" skills={intermediateSkills} />
+                    <SkillTier tierName="Beginner" skills={beginnerSkills} />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/profile/SkillTier.tsx
+++ b/src/components/profile/SkillTier.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+interface Skill {
+    name: string;
+    level: string; // 'Pro', 'Advanced', 'Intermediate', 'Beginner'
+    score: number; // 0-100
+    active: boolean; // 최근 6개월 내 활동 여부
+}
+
+interface SkillTierProps {
+    tierName: string;
+    skills: Skill[];
+}
+
+export default function SkillTier({ tierName, skills }: SkillTierProps) {
+    if (skills.length === 0) return null;
+
+    const isHighTier = ['Pro', 'Advanced'].includes(tierName);
+
+    // 상위 티어 (Pro, Advanced) - 초소형 카드형 그리드 레이아웃
+    if (isHighTier) {
+        return (
+            <div className="mb-6">
+                <h3 className={`text-base font-bold mb-3 px-2 py-0.5 inline-flex items-center rounded-md ${tierName === 'Pro'
+                        ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300'
+                        : 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+                    }`}>
+                    <span className="mr-1.5 text-sm">{tierName === 'Pro' ? '🏆' : '⚡'}</span>
+                    {tierName} Level
+                </h3>
+
+                <div className="grid grid-cols-3 md:grid-cols-5 gap-2">
+                    {skills.map((skill) => (
+                        <div key={skill.name} className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-2 hover:border-indigo-500 dark:hover:border-indigo-400 transition-colors duration-200 flex items-center justify-between group shadow-sm hover:shadow-md">
+                            <span className="font-semibold text-sm text-gray-700 dark:text-gray-300 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors truncate">
+                                {skill.name}
+                            </span>
+                            {skill.active && (
+                                <span className="relative flex h-1.5 w-1.5 flex-shrink-0 ml-2" title="Recent Activity">
+                                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+                                    <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-green-500"></span>
+                                </span>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
+    // 하위 티어 (Intermediate, Beginner) - 태그형 클라우드 레이아웃
+    return (
+        <div className="mb-4">
+            <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider px-1">
+                {tierName} Level
+            </h3>
+
+            <div className="flex flex-wrap gap-1.5">
+                {skills.map((skill) => (
+                    <div key={skill.name} className="inline-flex items-center px-2.5 py-1 rounded-md bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                        <span>{skill.name}</span>
+                        {skill.active && (
+                            <span className="ml-1.5 w-1.5 h-1.5 rounded-full bg-green-500" title="Recent Activity"></span>
+                        )}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/profile/StatusDashboard.tsx
+++ b/src/components/profile/StatusDashboard.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+interface StatusDashboardProps {
+    status?: string;
+}
+
+export default function StatusDashboard({ status = '구직중' }: StatusDashboardProps) {
+    // 상태에 따른 색상 및 텍스트 매핑
+    const getStatusStyle = (status: string) => {
+        switch (status) {
+            case '구직중':
+                return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border-green-200 dark:border-green-800';
+            case '재직중':
+                return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 border-blue-200 dark:border-blue-800';
+            case '팀빌딩중':
+                return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400 border-purple-200 dark:border-purple-800';
+            default:
+                return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300 border-gray-200 dark:border-gray-700';
+        }
+    };
+
+    return (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-700 h-full flex flex-col justify-between">
+            <div>
+                <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-3 uppercase tracking-wider">
+                    Current Status
+                </h3>
+                <div className={`inline-flex items-center px-4 py-2 rounded-xl border ${getStatusStyle(status)}`}>
+                    <span className="relative flex h-3 w-3 mr-3">
+                        <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 bg-current"></span>
+                        <span className="relative inline-flex rounded-full h-3 w-3 bg-current"></span>
+                    </span>
+                    <span className="font-bold text-sm">{status}</span>
+                </div>
+            </div>
+
+            <div className="mt-6">
+                <div className="flex justify-between items-end mb-2">
+                    <span className="text-sm font-medium text-gray-600 dark:text-gray-300">프로필 완성도</span>
+                    <span className="text-lg font-bold text-blue-600 dark:text-blue-400">45%</span>
+                </div>
+                <div className="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-2.5 overflow-hidden">
+                    <div className="bg-blue-600 h-2.5 rounded-full transition-all duration-500" style={{ width: '45%' }}></div>
+                </div>
+                <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
+                    기술 스택과 시간표를 입력하여 완성도를 높여보세요!
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/src/lib/models/Availability.ts
+++ b/src/lib/models/Availability.ts
@@ -1,0 +1,58 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+/**
+ * Availability 모델 인터페이스
+ * 사용자의 주간 가용 시간과 커뮤니케이션 성향을 저장합니다.
+ * schedule 필드는 availability-scheduler 라이브러리의 표준 포맷을 따릅니다.
+ */
+export interface IAvailability extends Document {
+    userId: mongoose.Types.ObjectId;
+    schedule: Array<{
+        day: string; // 요일 (예: 'monday', 'tuesday'...)
+        timeRanges: Array<{
+            start: string; // 시작 시간 (예: '09:00')
+            end: string;   // 종료 시간 (예: '12:00')
+        }>;
+    }>;
+    preference: number; // 0(완전 비동기) ~ 100(완전 동기)
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+const AvailabilitySchema: Schema = new Schema(
+    {
+        userId: {
+            type: Schema.Types.ObjectId,
+            ref: 'User',
+            required: true,
+            unique: true, // 유저당 하나의 가용성 정보만 존재
+        },
+        // availability-scheduler 호환 JSON 구조
+        schedule: [
+            {
+                day: {
+                    type: String,
+                    required: true,
+                    enum: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'],
+                },
+                timeRanges: [
+                    {
+                        start: { type: String, required: true },
+                        end: { type: String, required: true },
+                    },
+                ],
+            },
+        ],
+        preference: {
+            type: Number,
+            min: 0,
+            max: 100,
+            default: 50, // 기본값: 중간
+        },
+    },
+    {
+        timestamps: true,
+    }
+);
+
+export default mongoose.models.Availability || mongoose.model<IAvailability>('Availability', AvailabilitySchema);

--- a/src/lib/models/Skill.ts
+++ b/src/lib/models/Skill.ts
@@ -1,24 +1,45 @@
 import mongoose, { Document, Schema } from 'mongoose';
 
+/**
+ * Skill 모델 인터페이스
+ * 사용자가 보유한 기술 스택 정보를 저장합니다.
+ */
 export interface ISkill extends Document {
-  name: string;
-  category: string;
+  userId: mongoose.Types.ObjectId; // 사용자 참조
+  name: string; // 기술명 (예: React, Node.js)
+  level: string; // 숙련도 (예: Beginner, Intermediate, Advanced, Pro)
+  verified: boolean; // 검증 여부 (외부 연동 등)
+  icon?: string; // 아이콘 URL (선택)
   createdAt: Date;
+  updatedAt: Date;
 }
 
 const SkillSchema: Schema = new Schema(
   {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true, // 검색 성능 향상을 위한 인덱스
+    },
     name: {
       type: String,
       required: true,
-      unique: true,
       trim: true,
     },
-    category: {
+    level: {
       type: String,
       required: true,
-      enum: ['frontend', 'backend', 'mobile', 'devops', 'design', 'other'],
-      default: 'other',
+      enum: ['Beginner', 'Intermediate', 'Advanced', 'Pro'], // 숙련도 제한
+      default: 'Beginner',
+    },
+    verified: {
+      type: Boolean,
+      default: false,
+    },
+    icon: {
+      type: String,
+      default: '',
     },
   },
   {
@@ -26,4 +47,7 @@ const SkillSchema: Schema = new Schema(
   }
 );
 
-export default mongoose.models.Skill || mongoose.model<ISkill>('Skill', SkillSchema, 'skills');
+// 복합 인덱스: 한 유저가 같은 기술을 중복해서 등록하지 못하도록 방지
+SkillSchema.index({ userId: 1, name: 1 }, { unique: true });
+
+export default mongoose.models.Skill || mongoose.model<ISkill>('Skill', SkillSchema);

--- a/src/lib/models/User.ts
+++ b/src/lib/models/User.ts
@@ -9,6 +9,17 @@ export interface IUser extends Document {
   memberType: string;
   delYn: boolean;
   uid: number;
+  // 프로필 확장 필드
+  position?: string;
+  career?: string;
+  status?: string;
+  introduction?: string;
+  socialLinks?: {
+    github?: string;
+    blog?: string;
+    linkedin?: string;
+    other?: string;
+  };
   createdAt: Date;
   updatedAt: Date;
   comparePassword(candidatePassword: string): Promise<boolean>;
@@ -47,6 +58,17 @@ const UserSchema: Schema = new Schema(
       type: Number,
       required: true,
       unique: true,
+    },
+    // 프로필 확장 필드 스키마
+    position: { type: String, default: '' },
+    career: { type: String, default: '' }, // 예: 'Junior', 'Senior', '3년차' 등
+    status: { type: String, default: '구직중' }, // 예: '구직중', '재직중', '팀빌딩중'
+    introduction: { type: String, default: '' },
+    socialLinks: {
+      github: { type: String, default: '' },
+      blog: { type: String, default: '' },
+      linkedin: { type: String, default: '' },
+      other: { type: String, default: '' },
     },
   },
   {


### PR DESCRIPTION
- **DB 스키마**:
  - `User` 모델 확장 (직군, 경력, 상태 등 프로필 필드 추가).
  - 계층형 스킬 관리를 위한 `Skill` 모델 생성.
  - 스케줄 관리를 위한 `Availability` 모델 생성.

- **라우팅 및 레이아웃**:
  - `/tech`를 `/profile`로 변경 (공개 프로필).
  - `/profile`을 `/mypage`로 변경 (개인 대시보드).
  - `Header` 내비게이션 링크 업데이트.
  - 반응형 Split-Header 레이아웃 구현 (ProfileHeader + StatusDashboard).

- **UI 구현**:
  - `SkillSection` 및 `SkillTier` 컴포넌트 구현.
  - Ultra-Compact Hybrid Layout 적용:
    - 상위 티어 (Pro/Advanced): Active Dot이 포함된 소형 카드 (Grid 5).
    - 하위 티어 (Intermediate/Beginner): 단순 태그 (Chips).
  - 무거운 차트 라이브러리 제거 및 Tailwind CSS 커스텀 구현.

- **리팩토링**:
  - 컴포넌트 명칭 정리 (`TechPage` -> `ProfilePage`).
  - 새로운 `/mypage` 경로에 기존 마이페이지 기능 복구.