### PR TITLE
feat. step9. 포트폴리오 링크 미리보기 (Open Graph)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "mongoose": "^8.19.2",
         "next": "^14.2.35",
         "next-auth": "^4.24.13",
+        "open-graph-scraper": "^6.11.0",
         "postcss": "8.4.31",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -2340,6 +2341,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2542,6 +2549,54 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -2748,6 +2803,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -2757,6 +2828,18 @@
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
         "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -2974,6 +3057,61 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3028,6 +3166,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/engine.io": {
@@ -4549,6 +4712,37 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -6034,6 +6228,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
@@ -6200,6 +6406,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open-graph-scraper": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/open-graph-scraper/-/open-graph-scraper-6.11.0.tgz",
+      "integrity": "sha512-KkO3qMMzJj9KYGtCl19dRtncb+RuBiG/P9BgukcAG4p2w9wSAWTE90vL6/xqth1K9ThkYF/+xfTGrVvU79TJtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "cheerio": "^1.1.2",
+        "iconv-lite": "^0.7.0",
+        "undici": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/openid-client": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
@@ -6327,6 +6548,55 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -8635,6 +8905,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -8778,6 +9057,39 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mongoose": "^8.19.2",
     "next": "^14.2.35",
     "next-auth": "^4.24.13",
+    "open-graph-scraper": "^6.11.0",
     "postcss": "8.4.31",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/src/app/api/users/me/availability/route.ts
+++ b/src/app/api/users/me/availability/route.ts
@@ -17,16 +17,6 @@ export async function GET(request: Request) {
 
         const availability = await Availability.findOne({ userId: session.user._id });
 
-        if (availability) {
-            console.log(`[API] GET /availability found: ${availability.schedule?.length || 0} days`);
-            // 상세 데이터 로깅 (첫 번째 요일만 샘플로)
-            if (availability.schedule?.length > 0) {
-                console.log('[API] Sample Day:', JSON.stringify(availability.schedule[0]));
-            }
-        } else {
-            console.log('[API] GET /availability: No data found');
-        }
-
         return NextResponse.json({
             success: true,
             data: availability || { schedule: [], preference: 50, personalityTags: [] },

--- a/src/app/api/utils/og/route.ts
+++ b/src/app/api/utils/og/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import ogs from 'open-graph-scraper';
+
+/**
+ * @description
+ * 오픈 그래프(Open Graph) 메타데이터를 가져오는 API 라우트입니다.
+ * 
+ * [교육적 목적의 설명]
+ * 프론트엔드(브라우저)에서 직접 네이버나 유튜브 같은 외부 URL로 요청을 보내면 
+ * 브라우저 보안 정책인 CORS(Cross-Origin Resource Sharing) 에러가 발생합니다.
+ * 
+ * 이를 해결하기 위해 Next.js 서버(Backend)가 대신 요청을 보내고(Proxy), 
+ * 그 결과를 프론트엔드에 전달해주는 방식을 사용합니다.
+ */
+export async function GET(req: NextRequest) {
+    // 1. URL 쿼리 파라미터에서 target url 가져오기
+    const { searchParams } = new URL(req.url);
+    const targetUrl = searchParams.get('url');
+
+    // 유효성 검사: URL이 없으면 400 에러 반환
+    if (!targetUrl) {
+        return NextResponse.json({ error: 'URL 주소가 필요합니다.' }, { status: 400 });
+    }
+
+    try {
+        /**
+         * open-graph-scraper 라이브러리를 사용하여 메타데이터 추출
+         * 
+         * @param options
+         * - url: 스크래핑할 대상 주소
+         * - timeout: 무한 대기를 방지하기 위해 5초(5000ms) 제한 설정 (네트워크 지연 대비)
+         */
+        const { result, error } = await ogs({
+            url: targetUrl,
+            timeout: 5000,
+        });
+
+        if (error) {
+            console.error('OGS Error:', result);
+            throw new Error('오픈 그래프 정보를 가져오는데 실패했습니다.');
+        }
+
+        /**
+         * [데이터 정규화]
+         * 클라이언트가 사용하기 편하도록 필요한 데이터만 골라서 반환합니다.
+         * ogImage는 배열일 수도 있고 객체일 수도 있어서 안전하게 첫 번째 이미지를 선택합니다.
+         */
+        const responseData = {
+            title: result.ogTitle || result.twitterTitle || '',
+            description: result.ogDescription || result.twitterDescription || '',
+            image: result.ogImage?.[0]?.url || result.ogImage?.[0]?.url || null, // 배열 처리
+            url: result.ogUrl || targetUrl,
+            siteName: result.ogSiteName || '',
+        };
+
+        // 성공적으로 파싱된 데이터 반환 (Status 200)
+        return NextResponse.json(responseData);
+
+    } catch (err: any) {
+        console.error('API Error:', err.message);
+
+        // 실패하더라도 클라이언트가 깨지지 않도록 적절한 에러 메시지 반환
+        return NextResponse.json(
+            { error: '메타 데이터를 가져올 수 없습니다.', details: err.message },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -12,6 +12,8 @@ import AvailabilityScheduler from '@/components/profile/AvailabilityScheduler';
 import CommunicationStyleSlider from '@/components/profile/CommunicationStyleSlider';
 import BlockEditor from '@/components/editor/BlockEditor';
 import SolvedAcCard from '@/components/profile/external/SolvedAcCard';
+import PortfolioCard from '@/components/profile/portfolio/PortfolioCard';
+import LinkInput from '@/components/profile/portfolio/LinkInput';
 
 export default function ProfilePage() {
   const { data: session, status } = useSession();
@@ -28,6 +30,9 @@ export default function ProfilePage() {
 
   // 사용자 데이터 상태 (병합됨)
   const [userData, setUserData] = useState<any>(null);
+
+  // 포트폴리오 상태: 배열로 관리
+  const [portfolioLinks, setPortfolioLinks] = useState<string[]>([]);
 
   useEffect(() => {
     if (status === 'unauthenticated') {
@@ -72,6 +77,14 @@ export default function ProfilePage() {
       // 3. 자기소개 가져오기 (사용자 프로필이나 별도 API에 있다고 가정)
       // 현재는 기본 정보에 있는 것을 사용하거나 비워둠
       setIntroduction(basicInfo.introduction || ''); // API가 제공한다면 사용
+
+      // 4. 포트폴리오 링크 초기값 (Mock Data)
+      // 추후 API로 연동: const pfRes = await fetch('/api/users/me/portfolio');
+      setPortfolioLinks([
+        'https://velog.io/@hansanghun',
+        'https://github.com/facebook/react',
+        'https://www.youtube.com/watch?v=k1C8u4j03hU' // Next.js Conf
+      ]);
 
       setIsLoading(false);
     } catch (error) {
@@ -161,6 +174,42 @@ export default function ProfilePage() {
         <div className="lg:col-span-3">
           {userData?.socialLinks?.solvedAc && (
             <SolvedAcCard handle={userData.socialLinks.solvedAc} />
+          )}
+        </div>
+      </section>
+
+      {/* Phase 4: 포트폴리오 (오픈 그래프 미리보기) */}
+      <section className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
+        <h2 className="text-xl font-bold text-gray-800 mb-4 flex items-center gap-2">
+          📂 포트폴리오
+        </h2>
+        <div className="mb-6">
+          <LinkInput
+            onAdd={(url) => {
+              // 중복 체크 후 추가
+              if (!portfolioLinks.includes(url)) {
+                setPortfolioLinks([...portfolioLinks, url]);
+              } else {
+                alert('이미 추가된 링크입니다.');
+              }
+            }}
+          />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {portfolioLinks.map((url, idx) => (
+            <PortfolioCard
+              key={`${url}-${idx}`}
+              url={url}
+              onDelete={() => {
+                // 선택된 링크 삭제
+                setPortfolioLinks(portfolioLinks.filter(l => l !== url));
+              }}
+            />
+          ))}
+          {portfolioLinks.length === 0 && (
+            <div className="col-span-full py-8 text-center text-gray-400 text-sm bg-gray-50 rounded-lg border border-dashed border-gray-200">
+              등록된 포트폴리오가 없습니다. 링크를 추가해보세요!
+            </div>
           )}
         </div>
       </section>

--- a/src/components/profile/portfolio/LinkInput.tsx
+++ b/src/components/profile/portfolio/LinkInput.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useState, KeyboardEvent } from 'react';
+
+interface LinkInputProps {
+    onAdd: (url: string) => void; // URL 추가 시 실행될 부모 함수
+}
+
+/**
+ * @component LinkInput
+ * @description
+ * 사용자가 포트폴리오 URL을 입력하고 추가할 수 있는 컴포넌트입니다.
+ * 
+ * [주요 기능]
+ * 1. 입력창에 URL 입력 후 엔터 키 또는 '추가' 버튼 클릭 시 등록.
+ * 2. 간단한 유효성 검사 (빈 값 체크).
+ * 3. 추가 후 입력창 초기화.
+ */
+export default function LinkInput({ onAdd }: LinkInputProps) {
+    const [inputValue, setInputValue] = useState('');
+
+    // URL 추가 핸들러
+    const handleAdd = () => {
+        if (!inputValue.trim()) return;
+
+        // TODO: 필요하다면 여기서 정규식(Regex)으로 URL 포맷 검사를 강화할 수 있습니다.
+
+        onAdd(inputValue.trim());
+        setInputValue(''); // 입력창 비우기
+    };
+
+    // 키보드 엔터 이벤트 감지
+    const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault(); // Form submit 방지
+            handleAdd();
+        }
+    };
+
+    return (
+        <div className="flex gap-2 w-full">
+            <div className="relative flex-1">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    {/* 링크 아이콘 */}
+                    <svg className="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                    </svg>
+                </div>
+                <input
+                    type="url"
+                    className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 sm:text-sm transition-all"
+                    placeholder="https://..."
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                />
+            </div>
+            <button
+                onClick={handleAdd}
+                disabled={!inputValue.trim()}
+                className={`
+            px-4 py-2 rounded-lg font-medium text-sm transition-colors duration-200
+            ${inputValue.trim()
+                        ? 'bg-blue-600 text-white hover:bg-blue-700 shadow-sm'
+                        : 'bg-gray-200 text-gray-400 cursor-not-allowed'}
+        `}
+            >
+                추가
+            </button>
+        </div>
+    );
+}

--- a/src/components/profile/portfolio/PortfolioCard.tsx
+++ b/src/components/profile/portfolio/PortfolioCard.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+/**
+ * Open Graph API 응답 데이터 타입 정의
+ */
+interface OGData {
+    title: string;
+    description: string;
+    image: string | null;
+    url: string;
+    siteName: string;
+}
+
+interface PortfolioCardProps {
+    url: string;
+    onDelete?: () => void; // 삭제 기능이 필요할 때를 대비한 콜백
+    readOnly?: boolean;    // 조회 전용 모드인지 여부
+}
+
+/**
+ * @component PortfolioCard
+ * @description
+ * URL을 입력받아 해당 링크의 썸네일, 제목, 설명을 카드 형태로 보여주는 컴포넌트입니다.
+ * 
+ * [동작 원리]
+ * 1. 컴포넌트가 마운트되거나 URL이 변경되면 `/api/utils/og` API를 호출합니다.
+ * 2. 로딩 중에는 스켈레톤(Skeleton) UI를 보여줍니다.
+ * 3. 데이터 로드 완료 시 썸네일 이미지를 포함한 카드를 렌더링합니다.
+ * 4. 이미지 로드 실패 시 기본 아이콘으로 대체(Fallback)합니다.
+ */
+export default function PortfolioCard({ url, onDelete, readOnly = false }: PortfolioCardProps) {
+    const [data, setData] = useState<OGData | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<boolean>(false);
+
+    useEffect(() => {
+        // URL이 없으면 아무것도 하지 않음
+        if (!url) return;
+
+        const fetchOGData = async () => {
+            try {
+                setLoading(true);
+                setError(false);
+
+                // 우리가 만든 Proxy API 호출
+                const res = await fetch(`/api/utils/og?url=${encodeURIComponent(url)}`);
+
+                if (!res.ok) throw new Error('Failed to fetch OG data');
+
+                const result = await res.json();
+                setData(result);
+            } catch (err) {
+                console.error('OG Fetch Error:', err);
+                setError(true);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchOGData();
+    }, [url]);
+
+    // --- 1. 로딩 상태 UI (Skeleton) ---
+    if (loading) {
+        return (
+            <div className="w-full h-28 border border-gray-100 rounded-lg bg-gray-50 flex overflow-hidden animate-pulse">
+                {/* 썸네일 영역 스켈레톤 */}
+                <div className="w-28 h-full bg-gray-200"></div>
+                {/* 텍스트 영역 스켈레톤 */}
+                <div className="flex-1 p-3 space-y-2">
+                    <div className="h-4 bg-gray-200 rounded w-3/4"></div>
+                    <div className="h-3 bg-gray-200 rounded w-1/2"></div>
+                </div>
+            </div>
+        );
+    }
+
+    // --- 2. 에러 상태 UI (Fallback) ---
+    // API 호출이 실패했거나 데이터가 잘못된 경우, 간단한 링크 박스만 보여줌
+    if (error || !data) {
+        return (
+            <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block p-4 border border-red-100 bg-red-50 rounded-lg text-red-500 hover:bg-red-100 transition-colors"
+            >
+                <div className="text-sm font-semibold truncate">{url}</div>
+                <div className="text-xs mt-1">링크 정보를 불러올 수 없습니다. (클릭하여 이동)</div>
+            </a>
+        );
+    }
+
+    // --- 3. 성공 상태 UI (Card) ---
+    return (
+        <div className="group relative w-full border border-gray-200 rounded-lg overflow-hidden bg-white hover:shadow-md transition-all duration-200">
+
+            {/* 바로가기 링크 래퍼 */}
+            <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex h-28"
+            >
+                {/* 썸네일 이미지 */}
+                <div className="w-28 h-full flex-shrink-0 bg-gray-100 relative overflow-hidden">
+                    {data.image ? (
+                        <img
+                            src={data.image}
+                            alt={data.title}
+                            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                            onError={(e) => {
+                                // 이미지 로드 실패 시 회색 박스로 대체
+                                (e.target as HTMLImageElement).style.display = 'none';
+                            }}
+                        />
+                    ) : (
+                        // 이미지가 없을 경우 아이콘 표시
+                        <div className="w-full h-full flex items-center justify-center text-gray-400">
+                            <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                        </div>
+                    )}
+                </div>
+
+                {/* 텍스트 컨텐츠 */}
+                <div className="flex-1 p-3 min-w-0 flex flex-col justify-center">
+                    {/* 사이트 이름 (e.g. YouTube, Velog) */}
+                    {data.siteName && (
+                        <div className="text-xs text-indigo-500 font-semibold mb-1 uppercase tracking-wider">
+                            {data.siteName}
+                        </div>
+                    )}
+
+                    {/* 제목 */}
+                    <h3 className="text-sm font-bold text-gray-800 line-clamp-1 mb-1 group-hover:text-indigo-600 transition-colors">
+                        {data.title || url}
+                    </h3>
+
+                    {/* 설명 (최대 2줄) */}
+                    <p className="text-xs text-gray-500 line-clamp-2">
+                        {data.description || '설명이 없습니다.'}
+                    </p>
+                </div>
+            </a>
+
+            {/* 삭제 버튼 (편집 모드일 때만 노출) */}
+            {!readOnly && onDelete && (
+                <button
+                    onClick={(e) => {
+                        e.preventDefault(); // 링크 이동 방지
+                        e.stopPropagation();
+                        onDelete();
+                    }}
+                    className="absolute top-2 right-2 p-1 bg-white/80 rounded-full text-gray-400 hover:text-red-500 hover:bg-white shadow-sm opacity-0 group-hover:opacity-100 transition-all"
+                    title="삭제하기"
+                >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
사용자가 URL만 입력하면 썸네일, 제목, 설명을 자동으로 가져와 카드 형태로 보여줍니다.

1. Backend (API) [NEW] src/app/api/utils/og/route.ts
open-graph-scraper를 사용하여 요청된 URL의 메타데이터 파싱.
보안을 위해 User-Agent 헤더 설정 및 타임아웃 처리.
교육적 포인트: 왜 클라이언트가 아니라 서버에서 스크래핑을 해야 하는지(CORS 주석 설명).

2. Frontend (Component) [NEW] src/components/profile/portfolio/PortfolioCard.tsx 썸네일 이미지, 제목, 도메인, 설명 표시.
Hover 시 외부 링크 아이콘 표시 애니메이션.
[NEW] src/components/profile/portfolio/LinkInput.tsx URL 입력 -> Debounce 적용 -> API 호출 -> 미리보기 카드 렌더링.