### PR TITLE
칸반보드 개선점들 수정

### DIFF
--- a/src/app/dashboard/[pid]/layout.tsx
+++ b/src/app/dashboard/[pid]/layout.tsx
@@ -31,14 +31,15 @@ export default function DashboardLayout({
 
             {/* Mobile Toggle Button */}
             <button
-                className="md:hidden absolute top-4 left-4 z-50 p-2 bg-background border border-border rounded-md shadow-sm"
+                className="md:hidden absolute top-4 left-4 z-30 p-2 bg-background border border-border rounded-md shadow-sm"
                 onClick={toggleSidebar}
             >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     {isSidebarOpen ? (
                         <path d="M18 6L6 18M6 6l12 12" /> // X icon
                     ) : (
-                        <path d="M4 6h16M4 12h16M4 18h16" /> // Menu icon
+                        // Sidebar Icon (Rect with left column)
+                        <path d="M3 3h18v18H3zM9 3v18" />
                     )}
                 </svg>
             </button>

--- a/src/components/board/Minimap.tsx
+++ b/src/components/board/Minimap.tsx
@@ -209,14 +209,34 @@ export default function Minimap({
         setPan(newPanX, newPanY);
     };
 
+    const [isCollapsed, setIsCollapsed] = useState(false); // Default expanded on desktop? Maybe collapsed on mobile. 
+    // 모바일 감지는 여기서는 어려우므로 일단 기본은 펼침, 사용자가 접을 수 있게.
+
     return (
-        <canvas
-            ref={canvasRef}
-            className="border border-gray-300 bg-white shadow-lg rounded-lg cursor-crosshair"
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
-            style={{ touchAction: 'none' }}
-        />
+        <div className="flex flex-col items-end gap-2">
+            <button
+                onClick={(e) => { e.stopPropagation(); setIsCollapsed(!isCollapsed); }}
+                className="bg-white border border-gray-300 rounded-lg p-2 shadow-sm text-gray-700 hover:bg-gray-50 focus:outline-none dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700"
+                title={isCollapsed ? "미니맵 펼치기" : "미니맵 접기"}
+            >
+                {isCollapsed ? (
+                    /* Map Icon */
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6" /><line x1="8" y1="2" x2="8" y2="18" /><line x1="16" y1="6" x2="16" y2="22" /></svg>
+                ) : (
+                    /* Chevron Down Icon */
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9" /></svg>
+                )}
+            </button>
+            <div style={{ display: isCollapsed ? 'none' : 'block' }}>
+                <canvas
+                    ref={canvasRef}
+                    className="border border-gray-300 bg-white shadow-lg rounded-lg cursor-crosshair"
+                    onPointerDown={handlePointerDown}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerUp}
+                    style={{ touchAction: 'none' }}
+                />
+            </div>
+        </div>
     );
 }

--- a/src/store/boardStore.ts
+++ b/src/store/boardStore.ts
@@ -93,6 +93,12 @@ type BoardState = {
   updateSection: (id: string, patch: Partial<Section>) => void;
   removeSection: (id: string) => void;
   moveSection: (id: string, x: number, y: number) => void;
+
+  // Mobile/UX Logic
+  isSnapEnabled: boolean;
+  isSelectionMode: boolean; // For mobile multi-select without shift key
+  toggleSnap: () => void;
+  toggleSelectionMode: () => void;
 };
 
 const transformDoc = (doc: any) => {
@@ -117,6 +123,11 @@ export const useBoardStore = create<BoardState>()(
       alignmentGuides: [],
       lockedNotes: {},
       lockedSections: {},
+      isSnapEnabled: false, // Default off (or true depending on preference, user said "Always On" or toggle. Toggle default off is safer)
+      isSelectionMode: false,
+
+      toggleSnap: () => set((state) => ({ isSnapEnabled: !state.isSnapEnabled })),
+      toggleSelectionMode: () => set((state) => ({ isSelectionMode: !state.isSelectionMode })),
 
       initBoard: async (pid) => {
         set({ notes: [], sections: [], boardId: null, selectedNoteIds: [], members: [] });


### PR DESCRIPTION
1. 🖱️ 터치 영역 및 크기 문제 (Fitts's Law)
손가락 터치는 마우스 커서보다 훨씬 부정확합니다. 현재 UI 요소들이 너무 작아 터치하기 어렵습니다.

(1) 리사이즈 핸들 크기 (NoteItem.tsx)
문제점: 리사이즈 핸들(cursor: nwse-resize)의 크기가 20x20px로 설정되어 있습니다.

성인 손가락의 터치 영역은 최소 40x40px ~ 44x44px가 권장됩니다. 현재 크기로는 리사이즈 하려다 노트를 선택하거나 이동시켜버리는 오작동(Miss-touch)이 발생하기 쉽습니다.

해결책: 눈에 보이는 핸들 아이콘(Visual)은 작게 유지하더라도, 실제 터치 이벤트를 받는 투명 영역(Hit Area)을 늘려야 합니다.

(2) 버튼 크기 (NoteItem.tsx, BoardShell.tsx)
문제점: 노트의 닫기(x), 메뉴(...) 버튼이 28x28px입니다. 모바일에서는 최소 32px 이상, 권장 44px 이상이어야 스트레스 없이 누를 수 있습니다.


2. ⌨️ 키보드 단축키 의존성 (Keyboard Dependency)
PC에서는 당연하게 쓰던 Shift, Alt, Ctrl 키를 모바일에서는 입력할 수 없습니다. 이로 인해 작동하지 않는 핵심 기능들이 있습니다.

(1) 스냅 정렬 (NoteItem.tsx)
코드: if (e.altKey) { ... }

문제점: 모바일에서는 드래그 중에 Alt 키를 누를 방법이 없습니다. 따라서 "스마트 스냅" 기능을 모바일에서는 아예 쓸 수 없습니다.

해결책:

모바일에서는 스냅을 **기본값(Always On)**으로 켜두거나,

화면에 별도의 [자석 아이콘] 토글 버튼을 만들어 스냅 활성/비활성을 제어해야 합니다.

(2) 다중 선택 (BoardShell.tsx, NoteItem.tsx)
코드: if (e.shiftKey) { ... }

문제점: Shift + 드래그(영역 선택)나 Shift + 클릭(개별 추가)을 할 수 없습니다. 즉, 모바일에서는 노트를 한 번에 하나씩만 옮길 수 있습니다.

해결책: 모바일 헤더나 하단에 [선택 모드] 버튼을 추가하여, 해당 모드가 켜져 있을 때는 탭/드래그가 선택 동작으로 작동하도록 상태(isSelectionMode)를 분기해야 합니다.

(3) 노트 저장 및 줄바꿈 (NoteItem.tsx)
코드: e.key === 'Enter' && (e.metaKey || e.ctrlKey)

문제점: 모바일 키보드에는 Ctrl 키가 없습니다. 편집을 마치려면 밖을 터치(Blur)해야만 하는데, 이는 직관적이지 않을 수 있습니다.

해결책: 편집 모드(isEditing)일 때, 노트 우측 상단이나 키보드 상단에 [완료] 버튼을 명시적으로 보여주는 것이 좋습니다.

3. 👆 제스처 및 인터랙션 충돌
모바일 특유의 사용 방식과 현재 로직이 충돌하는 부분입니다.

(1) 텍스트 복사 불가 (NoteItem.tsx)
코드: userSelect: isEditing ? 'text' : 'none'

문제점: 편집 상태가 아닐 때 텍스트 선택을 막아(none) 두었습니다. PC에서는 드래그 이동을 원활하게 하기 위함이지만, 모바일에서는 사용자가 내용을 복사하기 위해 **"꾹 누르기(Long Press)"**를 시도할 때 아무 반응이 없어 답답함을 느낄 수 있습니다.

해결책: userSelect는 유지하되, 롱 프레스(Long Press) 이벤트를 감지하여 메뉴를 띄우거나, 편집 모드로 진입시켜 텍스트를 복사할 수 있게 유도해야 합니다.

(2) 호버(Hover) 효과 부재
현황: BoardShell.tsx 등의 버튼에 hover:bg-gray-... 스타일이 적용되어 있습니다.

문제점: 모바일에서는 호버가 없으므로, 버튼을 눌렀을 때(Active) 시각적 피드백이 명확해야 합니다. 터치했다가 뗄 때 색이 바뀌는 등 어색한 동작이 발생할 수 있습니다.

4. 미니맵 영역 크기 문제

문제점: 현재 모바일 모드에서도 미니맵 영역이 항상 펼쳐져 있어 사용자 입장에서 터치 영역에 영향을 줍니다.

해결책: 미니맵 영역을 펼치고 닫을 수 있도록 개선해야 합니다.


---