### PR TITLE
fix: ParsePhase 5: 버그수정 및 마무리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "cloudinary": "^2.8.0",
         "core-js": "^3.36.0",
         "date-fns": "^3.3.1",
+        "dompurify": "^3.3.1",
         "express": "^5.1.0",
         "gantt-task-react": "^0.3.9",
         "graphql": "^16.8.1",
@@ -51,6 +52,7 @@
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
+        "@types/dompurify": "^3.0.5",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/react-slick": "^0.23.13",
         "eslint": "8.56.0",
@@ -1247,6 +1249,16 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1451,6 +1463,13 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -3212,6 +3231,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cloudinary": "^2.8.0",
     "core-js": "^3.36.0",
     "date-fns": "^3.3.1",
+    "dompurify": "^3.3.1",
     "express": "^5.1.0",
     "gantt-task-react": "^0.3.9",
     "graphql": "^16.8.1",
@@ -38,8 +39,10 @@
     "postcss": "8.4.31",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-markdown": "^9.0.1",
     "react-schedule-selector": "^2.0.0",
     "react-slick": "^0.30.2",
+    "remark-gfm": "^4.0.0",
     "rss-parser": "^3.13.0",
     "slick-carousel": "^1.8.1",
     "socket.io": "^4.8.1",
@@ -47,12 +50,11 @@
     "styled-components": "^6.1.8",
     "tailwindcss": "3.4.1",
     "typescript": "5.3.3",
-    "zustand": "^4.5.2",
-    "react-markdown": "^9.0.1",
-    "remark-gfm": "^4.0.0"
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
+    "@types/dompurify": "^3.0.5",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/react-slick": "^0.23.13",
     "eslint": "8.56.0",

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -41,6 +41,7 @@ export async function GET(
         const profileData = {
             _id: user._id,
             nName: user.nName,
+            avatarUrl: user.avatarUrl, // [Fix] 프로필 이미지 추가
             // IUser has 'authorEmail', but frontend expects 'email'. We allow null/undefined handling.
             email: user.authorEmail || '',
             position: user.position || '포지션 미설정',
@@ -62,8 +63,29 @@ export async function GET(
             personalityTags: availability?.personalityTags || [],
 
             // 포트폴리오 (User 모델에 없을 수도 있으므로 방어 코드)
-            portfolioLinks: user.portfolioLinks || []
+            portfolioLinks: user.portfolioLinks || [],
+
+            // [Fix] 기술 스택 및 깃허브 통계 정보 추가
+            techTags: user.techTags || [],
+            githubStats: user.githubStats || {
+                followers: 0,
+                following: 0,
+                totalStars: 0,
+                totalCommits: 0,
+                totalPRs: 0,
+                totalIssues: 0,
+                contributions: 0,
+                techStack: []
+            },
+            level: user.level || 0,
+
+            // [Fix] 서버 주도 계산: 프로필 완성도
+            profileCompleteness: 0
         };
+
+        // Calculate completeness
+        const { calculateProfileCompleteness } = await import('@/lib/profileUtils');
+        profileData.profileCompleteness = calculateProfileCompleteness(profileData);
 
         return NextResponse.json({ success: true, data: profileData });
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { ICommonCode } from '@/lib/models/CommonCode';
+import ProjectThumbnail from '@/components/projects/ProjectThumbnail';
 
 interface Project {
     _id: string;
@@ -82,13 +83,13 @@ export default function DashboardHome() {
                             href={`/dashboard/${project.pid}`}
                             className="block bg-card rounded-xl shadow-sm hover:shadow-md transition-all border border-border overflow-hidden group"
                         >
-                            <div className="aspect-video bg-muted relative">
-                                {project.images && project.images.length > 0 ? (
-                                    <img src={project.images[0]} alt={project.title} className="w-full h-full object-cover" />
-                                ) : (
-                                    <div className="flex items-center justify-center h-full text-4xl">🚀</div>
-                                )}
-                                <div className="absolute top-2 right-2 px-2 py-1 bg-black/50 text-white text-xs rounded backdrop-blur-sm">
+                            <div className="aspect-video bg-muted relative overflow-hidden">
+                                <ProjectThumbnail
+                                    src={project.images && project.images.length > 0 ? project.images[0] : null}
+                                    alt={project.title}
+                                    fallbackText={project.title.charAt(0)}
+                                />
+                                <div className="absolute top-2 right-2 px-2 py-1 bg-black/50 text-white text-xs rounded backdrop-blur-sm z-10">
                                     {categoryCodes.find(c => c.code === project.category)?.label || project.category}
                                 </div>
                             </div>

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -16,7 +16,10 @@ interface PublicProfilePageProps {
  * 특정 사용자의 프로필을 조회만 할 수 있는 공개 페이지입니다.
  * - readOnly={true} 모드로 ProfileView를 렌더링합니다.
  */
+import { useSession } from 'next-auth/react';
+
 export default function PublicProfilePage({ params }: PublicProfilePageProps) {
+    const { data: session } = useSession();
     const [userData, setUserData] = useState<any>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
@@ -61,6 +64,9 @@ export default function PublicProfilePage({ params }: PublicProfilePageProps) {
         );
     }
 
-    // 핵심: readOnly={true} 전달
-    return <ProfileView initialUserData={userData} readOnly={true} />;
+    // [Fix] 내 프로필이면 수정 가능하도록 readOnly 해제
+    // session.user._id는 string일 수도 있고 ObjectId일 수도 있으므로 문자열 비교
+    const isMyProfile = session?.user && (session.user as any)._id === params.id;
+
+    return <ProfileView initialUserData={userData} readOnly={!isMyProfile} />;
 }

--- a/src/app/projects/[pid]/page.tsx
+++ b/src/app/projects/[pid]/page.tsx
@@ -8,6 +8,7 @@ import { useRouter, useParams } from 'next/navigation';
 import { IProject } from '@/lib/models/Project';
 import { useNotificationStore } from '@/lib/store/notificationStore';
 import DetailProfileCard from '@/components/profile/DetailProfileCard';
+import ProjectThumbnail from '@/components/projects/ProjectThumbnail';
 
 // 동적 임포트를 사용하여 이미지 슬라이더 컴포넌트를 로드 (SSR 제외)
 const ProjectImageSlider = dynamic(() => import('@/components/ProjectImageSlider'), {
@@ -291,7 +292,18 @@ export default function ProjectPage({ params }: ProjectPageProps) {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
           <div className="lg:col-span-2">
             <div className="prose dark:prose-invert max-w-none">
-              {project.images && project.images.length > 0 ? <ProjectImageSlider images={project.images} title={project.title} /> : <div className="aspect-video bg-muted rounded-lg mb-8 flex items-center justify-center text-8xl">🚀</div>}
+              {project.images && project.images.length > 0 ? (
+                <ProjectImageSlider images={project.images} title={project.title} />
+              ) : (
+                <div className="aspect-video bg-muted rounded-lg mb-8 overflow-hidden">
+                  <ProjectThumbnail
+                    src={null}
+                    alt={project.title}
+                    fallbackText={project.title.charAt(0)}
+                    className="text-8xl"
+                  />
+                </div>
+              )}
               <p className="text-lg leading-relaxed whitespace-pre-wrap text-foreground">{project.content}</p>
             </div>
 

--- a/src/components/ProjectImageSlider.tsx
+++ b/src/components/ProjectImageSlider.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import Slider from 'react-slick';
-import "slick-carousel/slick/slick.css"; 
+import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+import ProjectThumbnail from './projects/ProjectThumbnail';
 
 interface ProjectImageSliderProps {
   images: string[];
@@ -24,8 +25,13 @@ export default function ProjectImageSlider({ images, title }: ProjectImageSlider
     <div className="mb-8">
       <Slider {...settings}>
         {images.map((image, index) => (
-          <div key={index} className="aspect-video bg-gray-100 rounded-lg">
-            <img src={image} alt={`${title} 이미지 ${index + 1}`} className="w-full h-full object-cover rounded-lg" />
+          <div key={index} className="aspect-video bg-gray-100 rounded-lg relative overflow-hidden group">
+            <ProjectThumbnail
+              src={image}
+              alt={`${title} 이미지 ${index + 1}`}
+              fallbackText={title.charAt(0)}
+              className="rounded-lg"
+            />
           </div>
         ))}
       </Slider>

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -94,9 +94,16 @@ export default function ProfileView({ initialUserData, readOnly }: ProfileViewPr
             });
 
             if (!res.ok) throw new Error('Failed to save social links');
-            // Update global user data for other components
-            const updatedUserData = { ...userData, socialLinks: newLinks };
-            setUserData(updatedUserData);
+
+            const data = await res.json();
+            if (data.success && data.data) {
+                // 서버에서 계산된 최신 데이터(GitHub Stats, Tech Tags 등)로 전체 업데이트
+                setUserData(data.data);
+
+                // 개별 상태도 동기화 (SkillSection 등에 반영)
+                if (data.data.techTags) setTechTags(data.data.techTags);
+            }
+
             alert('소셜 링크가 저장되었습니다! ✅');
         } catch (error) {
             console.error(error);
@@ -240,8 +247,12 @@ export default function ProfileView({ initialUserData, readOnly }: ProfileViewPr
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ [field]: value })
             });
+
+            // [UX] 직군/경력 등 중요 정보 저장 시 사용자 피드백 제공 (요청사항)
+            alert('정보가 저장되었습니다! ✅');
         } catch (error) {
             console.error('Failed to save basic info:', error);
+            alert('저장 실패 ❌');
         }
     };
 

--- a/src/components/profile/StatusDashboard.tsx
+++ b/src/components/profile/StatusDashboard.tsx
@@ -2,6 +2,7 @@
 
 // StatusDashboard.tsx
 import { useEffect, useState } from 'react';
+import { calculateProfileCompleteness } from '@/lib/profileUtils';
 
 interface StatusDashboardProps {
     status?: string;
@@ -31,35 +32,8 @@ export default function StatusDashboard({ status = '구직중', user, isEditing,
 
     useEffect(() => {
         if (!user) return;
-
-        // Calculate completeness
-        let score = 0;
-        const total = 100;
-
-        // 1. Basic Info (30%)
-        if (user.avatarUrl) score += 15; // Real avatar exists
-        else if (user.avatarUrl) score += 5; // Default avatar (better than nothing logic? Maybe just check existence)
-
-        if (user.position && user.position.length > 0) score += 10;
-        if (user.career && user.career.length > 0) score += 5;
-
-        // 2. Content (40%)
-        if (user.introduction && user.introduction.length > 10) score += 20; // Meaningful intro
-        if (user.techTags && user.techTags.length > 0) score += 20;
-
-        // 3. Activity & Links (30%)
-        const socialCount = [
-            user.socialLinks?.github,
-            user.socialLinks?.blog,
-            user.socialLinks?.solvedAc,
-            ...(user.portfolioLinks || [])
-        ].filter(Boolean).length;
-
-        if (socialCount > 0) score += 15;
-
-        if (user.schedule && user.schedule.length > 0) score += 15;
-
-        setCompleteness(Math.min(score, 100));
+        // [Fix] 클라이언트에서 실시간 계산 (저장 전에도 반영됨) + 서버와 동일 로직 사용 (일관성 보장)
+        setCompleteness(calculateProfileCompleteness(user));
     }, [user]);
 
 
@@ -69,23 +43,33 @@ export default function StatusDashboard({ status = '구직중', user, isEditing,
             {/* Current Status removed as it is now in DetailProfileCard */}
 
             <div className="flex-1">
-                <div className="flex justify-between items-end mb-2">
-                    <span className="text-sm font-medium text-muted-foreground">프로필 완성도</span>
-                    <span className={`text-lg font-bold ${completeness === 100 ? 'text-green-600' : 'text-blue-600 dark:text-blue-400'}`}>
-                        {completeness}%
-                    </span>
-                </div>
-                <div className="w-full bg-muted rounded-full h-2.5 overflow-hidden">
-                    <div
-                        className={`h-2.5 rounded-full transition-all duration-1000 ease-out ${completeness === 100 ? 'bg-green-500' : 'bg-blue-600'}`}
-                        style={{ width: `${completeness}%` }}
-                    ></div>
-                </div>
-                <p className="text-xs text-muted-foreground mt-2">
-                    {completeness < 50 ? '기본 정보를 입력하여 신뢰도를 높여보세요!' :
-                        completeness < 80 ? '기술 스택과 소셜 링크를 추가해보세요.' :
-                            '완벽한 프로필입니다! 🚀'}
-                </p>
+                {/* [Fix] 타인 프로필에서는 완성도 점수 숨김 (요청사항) */}
+                {isEditing ? (
+                    <>
+                        <div className="flex justify-between items-end mb-2">
+                            <span className="text-sm font-medium text-muted-foreground">프로필 완성도</span>
+                            <span className={`text-lg font-bold ${completeness === 100 ? 'text-green-600' : 'text-blue-600 dark:text-blue-400'}`}>
+                                {completeness}%
+                            </span>
+                        </div>
+                        <div className="w-full bg-muted rounded-full h-2.5 overflow-hidden">
+                            <div
+                                className={`h-2.5 rounded-full transition-all duration-1000 ease-out ${completeness === 100 ? 'bg-green-500' : 'bg-blue-600'}`}
+                                style={{ width: `${completeness}%` }}
+                            ></div>
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-2">
+                            {completeness < 50 ? '기본 정보를 입력하여 신뢰도를 높여보세요!' :
+                                completeness < 80 ? '기술 스택과 소셜 링크를 추가해보세요.' :
+                                    '완벽한 프로필입니다! 🚀'}
+                        </p>
+                    </>
+                ) : (
+                    <div className="h-full flex items-center justify-center text-sm text-muted-foreground">
+                        {/* 타인 프로필일 때 보여줄 간단한 문구 또는 공란 */}
+                        <p>함께 성장하는 동료입니다 👋</p>
+                    </div>
+                )}
             </div>
 
             {/* Social Links Input Section (Only visible when editing) */}

--- a/src/components/profile/external/GitHubStats.tsx
+++ b/src/components/profile/external/GitHubStats.tsx
@@ -88,9 +88,9 @@ export default function GitHubStatsSection({ githubUrl }: GitHubStatsProps) {
             </h2>
 
             {/* Top Section: Analysis & Skills */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                 {/* Left: Activity Score / Level */}
-                <div className="flex flex-col items-center justify-center p-6 bg-gradient-to-br from-indigo-50/50 to-purple-50/50 dark:from-indigo-900/20 dark:to-purple-900/20 rounded-xl border border-indigo-100 dark:border-indigo-500/30">
+                <div className="flex flex-col items-center justify-center p-4 bg-gradient-to-br from-indigo-50/50 to-purple-50/50 dark:from-indigo-900/20 dark:to-purple-900/20 rounded-xl border border-indigo-100 dark:border-indigo-500/30">
                     <div className="text-sm text-indigo-600 dark:text-indigo-400 font-semibold mb-2">DEV LEVEL</div>
                     <div className="text-4xl font-extrabold text-indigo-900 dark:text-indigo-300 mb-1">LV. {stats.level.value}</div>
                     <div className="text-lg text-indigo-700 dark:text-indigo-200 font-medium bg-card px-3 py-1 rounded-full shadow-sm mb-4">
@@ -119,8 +119,9 @@ export default function GitHubStatsSection({ githubUrl }: GitHubStatsProps) {
 
                 {/* Right: Top Skills */}
                 <div className="flex flex-col h-full">
-                    <div className="text-sm text-muted-foreground font-semibold mb-3 uppercase tracking-wider">Top Skills via Contribution</div>
-                    <div className="space-y-2 flex-grow overflow-y-auto pr-1 custom-scrollbar" style={{ maxHeight: '250px' }}>
+                    <div className="text-sm text-muted-foreground font-semibold mb-2 uppercase tracking-wider">Top Skills via Contribution</div>
+                    {/* [Fix] Removed fixed height/scroll to prevent internal scrolling */}
+                    <div className="space-y-2 flex-grow pr-1">
                         {(() => {
                             const langs = stats.techTiers.map(t => ({ name: t.language, ...t, type: 'Lang' }));
                             const envs = (stats.envTiers || []).map(t => ({ name: t.topic, ...t, type: 'Env' }));
@@ -161,16 +162,16 @@ export default function GitHubStatsSection({ githubUrl }: GitHubStatsProps) {
             </div>
 
             {/* Bottom Section: Heatmap & Repos (New) */}
-            <div className="pt-6 border-t border-border">
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="pt-4 border-t border-border">
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                     {/* Mini Heatmap */}
                     <div>
-                        <div className="text-sm text-muted-foreground font-semibold mb-3 flex justify-between items-center">
+                        <div className="text-sm text-muted-foreground font-semibold mb-2 flex justify-between items-center">
                             <span>RECENT CONTRIBUTIONS</span>
                             <span className="text-xs font-normal bg-muted px-2 py-0.5 rounded text-foreground">Last 16 Weeks</span>
                         </div>
                         {stats.contributionCalendar?.weeks ? (
-                            <div className="flex gap-1 overflow-hidden" style={{ height: '80px', alignItems: 'flex-end' }}>
+                            <div className="flex gap-1 overflow-hidden h-[60px] items-end">
                                 {stats.contributionCalendar.weeks.slice(-16).map((week, wIdx) => (
                                     <div key={wIdx} className="flex flex-col gap-1">
                                         {week.contributionDays.map((day, dIdx) => {

--- a/src/components/projects/ProjectList.tsx
+++ b/src/components/projects/ProjectList.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { IProject } from '@/lib/models/Project';
 import { ICommonCode } from '@/lib/models/CommonCode';
+import ProjectThumbnail from './ProjectThumbnail';
 
 interface PopulatedProject extends Omit<IProject, 'tags' | 'author'> {
     author: { _id: string; nName: string } | string;
@@ -172,13 +173,11 @@ function ProjectListContent({ categoryCodes, statusCodes }: ProjectListProps) {
                             return (
                                 <Link key={project.pid} href={`/projects/${project.pid}`} className="bg-card rounded-xl shadow-sm hover:shadow-md transition-shadow duration-200 overflow-hidden group cursor-pointer border border-border">
                                     <div className="aspect-video bg-muted flex items-center justify-center overflow-hidden">
-                                        {project.images && project.images.length > 0 ? (
-                                            <img src={project.images[0]} alt={project.title} className="w-full h-full object-cover" />
-                                        ) : (
-                                            <div className="w-full h-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-white text-4xl font-bold">
-                                                {project.title.charAt(0)}
-                                            </div>
-                                        )}
+                                        <ProjectThumbnail
+                                            src={project.images && project.images.length > 0 ? project.images[0] : null}
+                                            alt={project.title}
+                                            fallbackText={project.title.charAt(0)}
+                                        />
                                     </div>
                                     <div className="p-5">
                                         <div className="flex items-center gap-2 mb-3">
@@ -230,6 +229,8 @@ function ProjectListContent({ categoryCodes, statusCodes }: ProjectListProps) {
  * 단순히 ProjectListContent를 Suspense로 감싸는 역할만 수행합니다.
  * 이렇게 해야 빌드 시 useSearchParams 관련 에러를 피할 수 있습니다.
  */
+
+
 export default function ProjectList(props: ProjectListProps) {
     return (
         <Suspense fallback={<div className="text-center py-20 text-foreground">페이지를 불러오는 중...</div>}>

--- a/src/components/projects/ProjectThumbnail.tsx
+++ b/src/components/projects/ProjectThumbnail.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface ProjectThumbnailProps {
+    src: string | null;
+    alt: string;
+    fallbackText: string;
+    className?: string;
+}
+
+export default function ProjectThumbnail({ src, alt, fallbackText, className }: ProjectThumbnailProps) {
+    const [error, setError] = useState(false);
+    const [currentSrc, setCurrentSrc] = useState<string | null>(src);
+
+    // src prop이 변경되면 상태 초기화
+    useEffect(() => {
+        setCurrentSrc(src);
+        setError(false);
+    }, [src]);
+
+    if (!currentSrc || error) {
+        return (
+            <div className={`w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-gray-400 dark:text-gray-500 font-bold ${className ? '' : 'text-4xl'}`}>
+                {fallbackText}
+            </div>
+        );
+    }
+
+    return (
+        <img
+            src={currentSrc}
+            alt={alt}
+            className={`w-full h-full object-cover transition-transform duration-300 group-hover:scale-105 ${className || ''}`}
+            onError={() => setError(true)}
+        />
+    );
+}

--- a/src/lib/github/service.ts
+++ b/src/lib/github/service.ts
@@ -1,0 +1,74 @@
+import User from '@/lib/models/User';
+import { githubClient } from '@/lib/github/client';
+import { GET_USER_STATS } from '@/lib/github/queries';
+import { calculateGitHubStats } from '@/lib/github/utils';
+
+/**
+ * 사용자의 GitHub 통계 및 기술 스택을 업데이트합니다.
+ * @param userId DB 유저 ID
+ * @param githubUrl 깃허브 프로필 URL (예: https://github.com/username)
+ */
+export async function updateUserGithubStats(userId: string, githubUrl: string): Promise<boolean> {
+    try {
+        if (!githubUrl) return false;
+
+        const cleanUrl = githubUrl.replace(/\/$/, ''); // Trailing slash 제거
+        const username = cleanUrl.split('/').pop();
+
+        if (!username) {
+            console.warn(`[GitHub Service] Invalid GitHub URL: ${githubUrl}`);
+            return false;
+        }
+
+        console.log(`[GitHub Service] Syncing stats for: ${username} (User: ${userId})`);
+
+        // GitHub API 호출
+        const data = await githubClient.request<any>(GET_USER_STATS, { username });
+        const stats = calculateGitHubStats(data);
+
+        if (!stats) {
+            console.warn(`[GitHub Service] Failed to calculate stats for: ${username}`);
+            return false;
+        }
+
+        // 통합 기술 스택 추출 (Language + Topic/Lib)
+        const techStackFromStats = [
+            ...stats.techTiers.map(t => t.language),
+            ...stats.envTiers.map(t => t.topic)
+        ];
+
+        // DB 업데이트
+        const user = await User.findById(userId);
+        if (!user) {
+            console.warn(`[GitHub Service] User not found: ${userId}`);
+            return false;
+        }
+
+        user.githubStats = {
+            followers: 0, // 기본값 0 (API 미지원)
+            following: 0,
+            totalStars: 0,
+            totalCommits: stats.activity.totalCommits,
+            totalPRs: stats.activity.totalPRs,
+            totalIssues: stats.activity.totalIssues,
+            contributions: stats.activity.totalCommits, // 근사치
+            techStack: techStackFromStats
+        };
+
+        // 기술 스택 병합 (기존 태그 유지 + 새 스택 추가)
+        if (techStackFromStats.length > 0) {
+            user.techTags = Array.from(new Set([...(user.techTags || []), ...techStackFromStats]));
+        }
+
+        // 레벨 업데이트 (계산된 레벨 사용)
+        user.level = stats.level.value;
+
+        await user.save();
+        console.log(`[GitHub Service] Successfully updated stats for ${username}`);
+        return true;
+
+    } catch (error) {
+        console.error(`[GitHub Service] Error updating stats:`, error);
+        return false;
+    }
+}

--- a/src/lib/profileUtils.ts
+++ b/src/lib/profileUtils.ts
@@ -1,0 +1,45 @@
+export interface ProfileCompletenessParams {
+    avatarUrl?: string;
+    position?: string;
+    career?: string;
+    introduction?: string;
+    techTags?: string[];
+    socialLinks?: {
+        github?: string;
+        blog?: string;
+        solvedAc?: string;
+    };
+    portfolioLinks?: string[];
+    schedule?: any[];
+}
+
+/**
+ * 사용자 프로필 데이터를 기반으로 완성도 점수(0~100)를 계산합니다.
+ * @param user 
+ */
+export function calculateProfileCompleteness(user: ProfileCompletenessParams): number {
+    let score = 0;
+
+    // 1. Basic Info (30%)
+    if (user.avatarUrl) score += 15;
+    if (user.position && user.position.length > 0) score += 10;
+    if (user.career && user.career.length > 0) score += 5;
+
+    // 2. Content (40%)
+    if (user.introduction && user.introduction.length > 10) score += 20;
+    if (user.techTags && user.techTags.length > 0) score += 20;
+
+    // 3. Activity & Links (30%)
+    const socialCount = [
+        user.socialLinks?.github,
+        user.socialLinks?.blog,
+        user.socialLinks?.solvedAc,
+        ...(user.portfolioLinks || [])
+    ].filter(Boolean).length;
+
+    if (socialCount > 0) score += 15;
+
+    if (user.schedule && user.schedule.length > 0) score += 15;
+
+    return Math.min(score, 100);
+}


### PR DESCRIPTION
# 1. 깃허브 통계 즉시 반영 및 API 개선
feat(profile): 깃허브 링크 저장 시 통계 즉시 업데이트 로직 추가
fix(api): 타인 프로필 조회 응답에 누락된 techTags 및 githubStats 필드 추가 
# 2. 프로필 입력 최적화 및 자기소개 렌더링 수정
perf(profile): BufferedInput 도입으로 입력 중 불필요한 API 호출 방지 fix(ui): 자기소개 줄바꿈 및 HTML 태그가 정상적으로 보이도록 수정 (DOMPurify 적용) 
# 3. 프로필 완성도 로직 개선
refactor(profile): 프로필 완성도 계산 로직을 서버 유틸리티로 통합 (불일치 해결) fix(ui): 타인 프로필 조회 시 완성도 그래프 숨김 처리
# 4. 내 프로필 자동 인식
fix(page): 내 프로필 URL로 접속 시 자동으로 수정 모드로 전환되도록 수정
# 5. UI 디자인 수정
style(profile): 깃허브 통계 영역 UI 최적화 (내부 스크롤 제거 및 여백 축소)