### PR TITLE
feat: 자산 박스 권한 로직 개선 및 알림 UI 공통화 (Phase 5)

### DIFF
--- a/src/app/api/projects/[pid]/resources/route.ts
+++ b/src/app/api/projects/[pid]/resources/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import dbConnect from '@/lib/mongodb';
 import Project from '@/lib/models/Project';
 import { headers } from 'next/headers';
+import mongoose from 'mongoose';
 import { fetchOGMetadata, validateResource } from '@/lib/utils/resourceUtils';
 
 export const dynamic = 'force-dynamic';
@@ -21,7 +22,7 @@ export async function PUT(
         }
 
         const body = await request.json();
-        const { resourceId, content, category, type, metadata } = body; // metadata 추가
+        const { resourceId, content, category, type, metadata } = body;
 
         if (!resourceId) {
             return NextResponse.json({ success: false, message: 'Resource ID가 필요합니다.' }, { status: 400 });
@@ -30,17 +31,27 @@ export async function PUT(
         await dbConnect();
         const { pid } = params;
 
-        // 프로젝트 조회 및 권한 확인
+        // 프로젝트 조회
         const project = await Project.findOne({ pid: Number(pid) });
         if (!project) {
             return NextResponse.json({ success: false, message: '프로젝트를 찾을 수 없습니다.' }, { status: 404 });
         }
 
-        if (project.author.toString() !== session.user._id) {
-            return NextResponse.json({ success: false, message: '수정 권한이 없습니다.' }, { status: 403 });
+        // 해당 리소스 확인
+        const resource = project.resources.id(resourceId);
+        if (!resource) {
+            return NextResponse.json({ success: false, message: '리소스를 찾을 수 없습니다.' }, { status: 404 });
         }
 
-        // 해당 리소스 찾아서 업데이트
+        // 권한 확인: 프로젝트 생성자(PM) 이거나 리소스 등록자 본인만 수정 가능
+        const isProjectAuthor = project.author.toString() === session.user._id;
+        const isResourceOwner = resource.userId?.toString() === session.user._id;
+
+        if (!isProjectAuthor && !isResourceOwner) {
+            return NextResponse.json({ success: false, message: '수정 권한이 없습니다. (본인이 등록한 자산만 수정 가능)' }, { status: 403 });
+        }
+
+        // 리소스 업데이트
         const updateFields: any = {
             'resources.$.content': content,
             'resources.$.category': category,
@@ -49,15 +60,13 @@ export async function PUT(
             updateFields['resources.$.metadata'] = metadata;
         }
 
+        // * 주의: userId는 변경하지 않음 (최초 등록자 유지)
+
         const updatedProject = await Project.findOneAndUpdate(
             { _id: project._id, 'resources._id': resourceId },
             { $set: updateFields },
             { new: true, runValidators: true }
         );
-
-        if (!updatedProject) {
-            return NextResponse.json({ success: false, message: '리소스를 찾을 수 없거나 업데이트에 실패했습니다.' }, { status: 404 });
-        }
 
         return NextResponse.json({ success: true, message: '리소스가 수정되었습니다.', data: updatedProject.resources });
     } catch (error: any) {
@@ -84,32 +93,46 @@ export async function POST(
         await dbConnect();
         const { pid } = params;
 
-        // 프로젝트 조회 및 권한 확인
+        // 프로젝트 조회
         const project = await Project.findOne({ pid: Number(pid) });
         if (!project) {
             return NextResponse.json({ success: false, message: '프로젝트를 찾을 수 없습니다.' }, { status: 404 });
         }
 
-        if (project.author.toString() !== session.user._id) {
-            return NextResponse.json({ success: false, message: '수정 권한이 없습니다.' }, { status: 403 });
+        // 권한 확인: 프로젝트 멤버라면 누구나 등록 가능!
+        // 1. 프로젝트 생성자(PM)인지 확인 (패스)
+        // 2. 멤버 리스트(ProjectMember)에 있는지 확인
+        const isProjectAuthor = project.author.toString() === session.user._id;
+
+        // * ProjectMember 모델을 동적 import 하거나 상단에서 import 필요 (여기서는 상단 추가 가정하거나 직접 쿼리)
+        // 간단하게 ProjectMember collection 직접 조회
+        const isMember = await mongoose.model('ProjectMember').exists({
+            projectId: project._id,
+            userId: session.user._id,
+            status: 'active'
+        });
+
+        if (!isProjectAuthor && !isMember) {
+            return NextResponse.json({ success: false, message: '프로젝트 멤버만 자산을 등록할 수 있습니다.' }, { status: 403 });
         }
 
         const body = await request.json();
         const { type, category, content, metadata } = body;
 
-        // 1. 유효성 검사 (유틸리티 사용)
+        // 1. 유효성 검사
         const validation = validateResource(type, category, content);
         if (!validation.valid) {
             return NextResponse.json({ success: false, message: validation.message }, { status: 400 });
         }
 
-        // 2. 메타데이터 처리 (LINK 타입인 경우 OG 정보 자동 수집)
+        // 2. 메타데이터 처리
         let finalMetadata = metadata || {};
         if (type === 'LINK') {
             const ogData = await fetchOGMetadata(content);
             finalMetadata = { ...ogData, ...finalMetadata };
         }
 
+        // 3. 리소스 추가 (userId 포함!)
         const updatedProject = await Project.findByIdAndUpdate(
             project._id,
             {
@@ -119,6 +142,7 @@ export async function POST(
                         category,
                         content,
                         metadata: finalMetadata,
+                        userId: session.user._id, // ✨ 등록자 ID 저장
                     },
                 },
             },
@@ -157,14 +181,27 @@ export async function DELETE(
         await dbConnect();
         const { pid } = params;
 
-        // 프로젝트 조회 및 권한 확인
+        // 프로젝트 조회
         const project = await Project.findOne({ pid: Number(pid) });
         if (!project) {
             return NextResponse.json({ success: false, message: '프로젝트를 찾을 수 없습니다.' }, { status: 404 });
         }
 
-        if (project.author.toString() !== session.user._id) {
-            return NextResponse.json({ success: false, message: '삭제 권한이 없습니다.' }, { status: 403 });
+        // 해당 리소스 확인
+        const resource = project.resources.id(resourceId);
+        if (!resource) {
+            return NextResponse.json({ success: false, message: '이미 삭제되었거나 존재하지 않는 리소스입니다.' }, { status: 404 });
+        }
+
+        // 권한 확인
+        // 1. 프로젝트 생성자(PM): 모든 리소스 삭제 가능
+        // 2. 리소스 등록자(Owner): 본인 리소스만 삭제 가능
+        const isProjectAuthor = project.author.toString() === session.user._id;
+        const isResourceOwner = resource.userId?.toString() === session.user._id;
+
+        // 기존 데이터 호환성: userId가 없는 레거시 데이터는 PM만 삭제 가능
+        if (!isProjectAuthor && !isResourceOwner) {
+            return NextResponse.json({ success: false, message: '삭제 권한이 없습니다. (본인이 등록한 자산만 삭제 가능)' }, { status: 403 });
         }
 
         const updatedProject = await Project.findByIdAndUpdate(

--- a/src/lib/models/Project.ts
+++ b/src/lib/models/Project.ts
@@ -9,6 +9,7 @@ export interface IResource {
   category: 'CODE' | 'DESIGN' | 'DOCS' | 'ENV' | 'ACCOUNT' | 'OTHER'; // 리소스 분류
   content: string; // URL 또는 텍스트 내용
   metadata?: Record<string, any>; // OG 태그 정보나 추가 설명을 위한 메타데이터
+  userId?: string | any; // ✨ [추가] 리소스 등록자 ID
   _id?: string; // 클라이언트 식별용
 }
 
@@ -75,6 +76,7 @@ const ProjectSchema: Schema = new Schema(
         },
         content: { type: String, required: true },
         metadata: { type: Object }, // 유연성을 위해 Object 타입 사용 (OG 정보 등)
+        userId: { type: Schema.Types.ObjectId, ref: 'User' }, // ✨ [추가] 등록자 추적
       },
     ],
     deadline: { type: Date },


### PR DESCRIPTION
[주요 변경 사항]
1. ✨ 자산 등록 실명제 도입 & 권한 로직 대개편
   - DB Schema: Resource 스키마에 `userId` 필드 추가 (누가 올렸는지 추적!)
   - API (POST): 프로젝트 멤버라면 누구나 자산 등록 가능하도록 권한 완화
   - API (DELETE/PUT): '내 건 내가, 남의 건 관리자만' 삭제/수정 가능하도록 권한 강화 구현

2. 🎨 UI/UX 퀄리티 업그레이드
   - [GlobalModal](cci:1://file:///c:/Users/Admin/WebstormProjects/sideProjectMate/src/components/common/GlobalModal.tsx:5:0-164:2) 전면 적용: 못생긴 시스템 alert/confirm 제거하고 전역 모달 연결
   - 스마트한 버튼 노출: 권한 없는 자산에는 수정/삭제 버튼이 아예 안 보이게 처리 ([ResourceModal](cci:1://file:///c:/Users/Admin/WebstormProjects/sideProjectMate/src/components/dashboard/ResourceModal.tsx:15:0-481:1))

3. 🔧 Refactoring
   - 페이지([page.tsx](cci:7://file:///c:/Users/Admin/WebstormProjects/sideProjectMate/src/app/dashboard/%5Bpid%5D/page.tsx:0:0-0:0))에서 모달 스토어 연동 및 Props 드릴링 구조 개선