### PR TITLE
Refactor: 대시보드 레이아웃 구조 개편 및 칸반보드 UI 버그 수정

### DIFF
--- a/src/app/dashboard/[pid]/kanban/page.tsx
+++ b/src/app/dashboard/[pid]/kanban/page.tsx
@@ -10,7 +10,12 @@ export default function KanbanPage({ params }: { params: { pid: string } }) {
     const pid = parseInt(params.pid, 10);
 
     return (
-        <div className="w-full h-full">
+        /* 
+            칸반보드 페이지 독립적 스타일
+            - h-[calc(100vh-64px)]: 헤더 제외 전체 높이 고정
+            - overflow-hidden: 브라우저 스크롤 방지 및 내부 보드 스크롤 활성화
+        */
+        <div className="w-full h-[calc(100vh-64px)] overflow-hidden">
             <BoardShell pid={pid} />
         </div>
     );

--- a/src/app/dashboard/[pid]/layout.tsx
+++ b/src/app/dashboard/[pid]/layout.tsx
@@ -17,6 +17,90 @@ interface ProjectData {
     projectMembers: ProjectMember[];
 }
 
+/**
+ * 사이드바 내부 컨텐츠 컴포넌트
+ * 홈과 작업 페이지 드로어에서 공통으로 사용됩니다.
+ */
+const SidebarContent = ({
+    pid,
+    isActive,
+    onClose
+}: {
+    pid: string;
+    isActive: (path: string) => boolean;
+    onClose?: () => void;
+}) => (
+    <>
+        <div className="p-6 border-b border-border flex justify-between items-center">
+            <div>
+                <h2 className="text-xl font-bold text-foreground">프로젝트 메뉴</h2>
+                <p className="text-sm text-muted-foreground">ID: {pid}</p>
+            </div>
+            {onClose && (
+                <button
+                    className="md:hidden p-2 hover:bg-muted rounded-full transition-colors"
+                    onClick={onClose}
+                >
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M18 6L6 18M6 6l12 12" />
+                    </svg>
+                </button>
+            )}
+        </div>
+
+        <nav className="flex-1 p-6 space-y-3 bg-muted/5 overflow-y-auto">
+            <Link
+                href={`/dashboard/${pid}`}
+                onClick={() => onClose?.()}
+                className={`flex items-center px-4 py-3 rounded-xl text-base font-semibold transition-all ${isActive(`/dashboard/${pid}`)
+                    ? 'bg-primary text-primary-foreground shadow-lg shadow-primary/20 scale-[1.02]'
+                    : 'text-muted-foreground hover:bg-muted dark:hover:bg-muted/50 hover:pl-6'
+                    }`}
+            >
+                <svg className="mr-3 w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                    <polyline points="9 22 9 12 15 12 15 22" />
+                </svg>
+                대쉬보드 홈
+            </Link>
+            <Link
+                href={`/dashboard/${pid}/kanban`}
+                onClick={() => onClose?.()}
+                className={`flex items-center px-4 py-3 rounded-xl text-base font-semibold transition-all ${isActive(`/dashboard/${pid}/kanban`)
+                    ? 'bg-primary text-primary-foreground shadow-lg shadow-primary/20 scale-[1.02]'
+                    : 'text-muted-foreground hover:bg-muted dark:hover:bg-muted/50 hover:pl-6'
+                    }`}
+            >
+                <svg className="mr-3 w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                    <line x1="9" y1="3" x2="9" y2="21" />
+                </svg>
+                칸반보드
+            </Link>
+            <Link
+                href={`/dashboard/${pid}/wbs`}
+                onClick={() => onClose?.()}
+                className={`flex items-center px-4 py-3 rounded-xl text-base font-semibold transition-all ${isActive(`/dashboard/${pid}/wbs`)
+                    ? 'bg-primary text-primary-foreground shadow-lg shadow-primary/20 scale-[1.02]'
+                    : 'text-muted-foreground hover:bg-muted dark:hover:bg-muted/50 hover:pl-6'
+                    }`}
+            >
+                <svg className="mr-3 w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                    <line x1="16" y1="2" x2="16" y2="6" />
+                    <line x1="8" y1="2" x2="8" y2="6" />
+                    <line x1="3" y1="10" x2="21" y2="10" />
+                </svg>
+                WBS (일정)
+            </Link>
+        </nav>
+
+        <div className="p-6 border-t border-border bg-muted/10 mt-auto">
+            <p className="text-[10px] text-muted-foreground uppercase tracking-widest font-bold">Side Project Mate</p>
+        </div>
+    </>
+);
+
 export default function DashboardLayout({
     children,
     params,
@@ -26,23 +110,21 @@ export default function DashboardLayout({
 }) {
     const pathname = usePathname();
     const { pid } = params;
-
-    // Helper to check active link
-    const isActive = (path: string) => pathname === path;
-
     const router = useRouter();
-    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
     const { data: session, status } = useSession();
-    const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null); // null: loading
 
+    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+    const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
+
+    // 대시보드 홈 여부 확인
+    const isHomePage = pathname === `/dashboard/${pid}`;
+    const isActive = (path: string) => pathname === path;
     const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 
-    // Close sidebar when path changes (mobile)
     useEffect(() => {
         setIsSidebarOpen(false);
     }, [pathname]);
 
-    // Access Control Check
     useEffect(() => {
         const checkAccess = async () => {
             if (status === 'loading') return;
@@ -95,88 +177,72 @@ export default function DashboardLayout({
         );
     }
 
-    if (isAuthorized === false) {
-        return null; // Redirecting...
-    }
+    if (isAuthorized === false) return null;
 
     return (
-        <div className="flex h-[calc(100vh-64px)] relative"> {/* Header height assumed 64px */}
+        <div className="flex min-h-[calc(100vh-64px)] relative bg-background">
 
-            {/* Mobile Toggle Button */}
-            <button
-                className="md:hidden absolute top-4 left-4 z-30 p-2 bg-background border border-border rounded-md shadow-sm"
-                onClick={toggleSidebar}
-            >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    {isSidebarOpen ? (
-                        <path d="M18 6L6 18M6 6l12 12" /> // X icon
-                    ) : (
-                        // Sidebar Icon (Rect with left column)
-                        <path d="M3 3h18v18H3zM9 3v18" />
-                    )}
-                </svg>
-            </button>
+            {/* 1. 홈 전용: 데스크탑 고정 사이드바 */}
+            {isHomePage && (
+                <aside className="hidden md:flex w-72 border-r border-border flex-col sticky top-[64px] h-[calc(100vh-64px)] bg-background">
+                    <SidebarContent pid={pid} isActive={isActive} />
+                </aside>
+            )}
 
-            {/* Mobile Sidebar Overlay */}
+            {/* 2. 공통: 드로어 사이드바 (모바일 & 작업 페이지 데스크탑용) */}
+            {/* Backdrop */}
             {isSidebarOpen && (
                 <div
-                    className="fixed inset-0 bg-black/50 z-40 md:hidden"
+                    className="fixed inset-0 bg-black/50 z-[100] transition-opacity duration-300 ease-in-out"
                     onClick={() => setIsSidebarOpen(false)}
                 />
             )}
 
-            {/* 사이드바 */}
+            {/* Drawer Aside */}
             <aside
                 className={`
-                    fixed md:static inset-y-0 left-0 z-50 w-64 bg-background border-r border-border flex flex-col transition-transform duration-300 ease-in-out
-                    ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
+                    fixed inset-y-0 left-0 z-[101] w-72 bg-background border-r border-border flex flex-col shadow-2xl transition-transform duration-300 ease-in-out
+                    ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'}
                 `}
             >
-                <div className="p-6 border-b border-border flex justify-between items-center">
-                    <div>
-                        <h2 className="text-lg font-bold text-foreground">프로젝트 {pid}</h2>
-                        <p className="text-sm text-muted-foreground">대쉬보드</p>
-                    </div>
-                    {/* Mobile Close Button (Inside Sidebar) */}
-                    <button className="md:hidden" onClick={() => setIsSidebarOpen(false)}>
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                            <path d="M15 19l-7-7 7-7" /> {/* Left Chevron */}
-                        </svg>
-                    </button>
-                </div>
-                <nav className="flex-1 p-4 space-y-2 bg-muted/20">
-                    <Link
-                        href={`/dashboard/${pid}`}
-                        className={`block px-4 py-2 rounded-lg text-sm font-medium transition-colors ${isActive(`/dashboard/${pid}`)
-                            ? 'bg-primary/10 text-primary'
-                            : 'text-muted-foreground hover:bg-muted dark:hover:bg-muted/50'
-                            }`}
-                    >
-                        홈
-                    </Link>
-                    <Link
-                        href={`/dashboard/${pid}/kanban`}
-                        className={`block px-4 py-2 rounded-lg text-sm font-medium transition-colors ${isActive(`/dashboard/${pid}/kanban`)
-                            ? 'bg-primary/10 text-primary'
-                            : 'text-muted-foreground hover:bg-muted dark:hover:bg-muted/50'
-                            }`}
-                    >
-                        칸반보드
-                    </Link>
-                    <Link
-                        href={`/dashboard/${pid}/wbs`}
-                        className={`block px-4 py-2 rounded-lg text-sm font-medium transition-colors ${isActive(`/dashboard/${pid}/wbs`)
-                            ? 'bg-primary/10 text-primary'
-                            : 'text-muted-foreground hover:bg-muted dark:hover:bg-muted/50'
-                            }`}
-                    >
-                        WBS
-                    </Link>
-                </nav>
+                <SidebarContent
+                    pid={pid}
+                    isActive={isActive}
+                    onClose={() => setIsSidebarOpen(false)}
+                />
             </aside>
 
-            {/* 메인 컨텐츠 */}
-            <main className="flex-1 relative overflow-hidden bg-background w-full">
+            {/* 3. 트리거 버튼 분기 */}
+            {isHomePage ? (
+                /* 홈 페이지: 모바일 전용 햄버거 버튼 */
+                <button
+                    onClick={toggleSidebar}
+                    className="md:hidden fixed bottom-6 left-6 z-[90] w-12 h-12 bg-primary text-primary-foreground rounded-full shadow-lg flex items-center justify-center transition-transform active:scale-90"
+                >
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M3 12h18M3 6h18M3 18h18" />
+                    </svg>
+                </button>
+            ) : (
+                /* 작업 페이지: 개선된 플로팅 트리거 (손잡이 형태) */
+                !isSidebarOpen && (
+                    <button
+                        onClick={toggleSidebar}
+                        className="fixed left-0 top-1/2 -translate-y-1/2 z-[40] w-4 h-20 bg-background border-y border-r border-border rounded-r-2xl shadow-[4px_0_15px_rgba(0,0,0,0.1)] flex items-center justify-center hover:w-8 transition-all group overflow-hidden"
+                        title="메뉴 열기"
+                    >
+                        <svg
+                            className="text-muted-foreground group-hover:text-primary transition-colors w-4 h-4 ml-[-2px] group-hover:ml-0"
+                            viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"
+                        >
+                            <polyline points="9 18 15 12 9 6" />
+                        </svg>
+                    </button>
+                )
+            )}
+
+            {/* 4. 메인 컨텐츠 */}
+            <main className={`flex-1 relative w-full ${isHomePage ? 'min-w-0' : ''}`}>
                 {children}
             </main>
         </div>

--- a/src/app/dashboard/[pid]/wbs/page.tsx
+++ b/src/app/dashboard/[pid]/wbs/page.tsx
@@ -206,7 +206,7 @@ export default function WBSPage({ params }: { params: { pid: string } }) {
     }
 
     return (
-        <div className="flex flex-col h-full overflow-hidden">
+        <div className="flex flex-col min-h-full">
             {/* 상단 툴바 */}
             <div className="flex items-center justify-between px-6 py-4 bg-card border-b border-border">
                 <div>
@@ -312,8 +312,8 @@ export default function WBSPage({ params }: { params: { pid: string } }) {
                 return null;
             })()}
 
-            {/* 메인 컨텐츠 */}
-            <div className="flex-1 overflow-auto p-6 space-y-6">
+            {/* 메인 컨텐츠 (브라우저 스크롤 활용) */}
+            <div className="p-6 space-y-6">
                 {/* 작업 폼 (모달 형태) */}
                 {showTaskForm && (
                     <div className="mb-6">

--- a/src/components/board/NoteItem.tsx
+++ b/src/components/board/NoteItem.tsx
@@ -746,18 +746,26 @@ export default function NoteItem({
     debouncedSave({ x: newX, y: newY });
   }, [isEditing, x, y, id, moveNote, debouncedSave, setIsEditing, removeNote]);
 
+  // --- Box-Shadow (Border Replacement) ---
+  const baseShadow = '0 2px 8px rgba(0,0,0,0.15)';
+  let ringShadow = '';
+
+  if (isLockedByOther) {
+    ringShadow = `inset 0 0 0 3px ${lockedColor}`;
+  } else if (isSelected) {
+    ringShadow = `inset 0 0 0 2px #3B82F6`;
+  } else if (isPeerSelected) {
+    ringShadow = `inset 0 0 0 2px ${peerColor}`;
+  }
+
+  const finalShadow = ringShadow ? `${baseShadow}, ${ringShadow}` : baseShadow;
+
   return (
     <div
       ref={visualRef} // Attach Ref
       role="note"
       data-note-id={id} // For DOM manipulation
-      data-section-id={useBoardStore.getState().notes.find(n => n.id === id)?.sectionId || ''} // 섹션 연결용 (props로 받는게 정확하지만 store에서 조회가 안전)
-      // Note: props로 받는게 좋은데, NoteItem은 props로 sectionId를 안받고 있음?
-      // 아, Note 타입 text, color 등등만 받고 sectionId는 안받았었나?
-      // Props 정의 다시 확인: width, height, ... tags. sectionId 없음.
-      // 근데 store에는 있음.
-      // NoteItem은 'Note' 객체를 통째로 안받고 분해해서 받음.
-      // -> useBoardStore에서 조회해서 넣어야함.
+      data-section-id={useBoardStore.getState().notes.find(n => n.id === id)?.sectionId || ''}
       tabIndex={0}
       onKeyDown={handleKeyDown}
       onTouchEnd={handleTouchEnd}
@@ -775,16 +783,13 @@ export default function NoteItem({
         width: width,
         height: height,
         background: color,
-        boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+        boxShadow: finalShadow,
         borderRadius: 12,
         padding: 0,
         cursor: isEditing ? 'text' : 'grab',
         userSelect: isEditing ? 'text' : 'none',
         touchAction: 'none',
         overscrollBehavior: 'contain',
-        borderWidth: isLockedByOther ? 3 : (isSelected || isPeerSelected ? 2 : 0),
-        borderStyle: 'solid',
-        borderColor: isLockedByOther ? lockedColor : (isSelected ? '#3B82F6' : (isPeerSelected ? peerColor : 'transparent')),
         outline: 'none',
         opacity: isTempNote ? 0.7 : 1,
         zIndex: isSelected ? 9999 : zIndex,

--- a/src/components/board/ZoomController.tsx
+++ b/src/components/board/ZoomController.tsx
@@ -21,7 +21,7 @@ const ZoomController: React.FC<Props> = ({ onFit }) => {
                 className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-accent text-muted-foreground hover:text-foreground font-medium transition-colors pointer-events-auto"
                 title="Zoom Out (-)"
             >
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="pointer-events-none">
                     <line x1="5" y1="12" x2="19" y2="12"></line>
                 </svg>
             </button>
@@ -35,7 +35,7 @@ const ZoomController: React.FC<Props> = ({ onFit }) => {
                 className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-accent text-muted-foreground hover:text-foreground font-medium transition-colors pointer-events-auto"
                 title="Zoom In (+)"
             >
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="pointer-events-none">
                     <line x1="12" y1="5" x2="12" y2="19"></line>
                     <line x1="5" y1="12" x2="19" y2="12"></line>
                 </svg>


### PR DESCRIPTION
[대시보드 레이아웃 개편]
- 공통 Layout의 강제 높이/스크롤 속성 제거 (페이지별 독립 스크롤 적용)
- 하이브리드 사이드바 구현:
  - 대시보드 홈: 고정형(Static) 사이드바 유지
  - 칸반/WBS: 작업 공간 확보를 위한 서랍형(Drawer) 사이드바 적용
- 좌측 사이드바 플로팅(탭 형태) 트리거 버튼 추가

[칸반보드 UI/UX 수정]
- 줌 컨트롤러 아이콘 클릭 시 이벤트 씹힘 현상 수정 (pointer-events-none)
- 노트 선택 시 텍스트 밀림(Layout Shift) 현상 수정 (Border -> Box-shadow 변경)