### PR TITLE
feat(chat): [Phase 2] 상황별 채팅방 생성 트리거 및 페이지 연동 구현

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+// 🚧 [임시 페이지] 채팅 기능 구현 전 라우팅 테스트용 페이지
+export default function ChatPage() {
+    return (
+        <div className="flex items-center justify-center min-h-screen bg-slate-100">
+            <div className="text-center">
+                <h1 className="text-4xl font-bold text-slate-800 mb-4">💬 채팅 페이지</h1>
+                <p className="text-slate-600">아직 채팅 기능이 구현되지 않았습니다.</p>
+                <p className="text-slate-500 text-sm mt-2">Phase 3에서 UI가 구현될 예정입니다.</p>
+            </div>
+        </div>
+    );
+}

--- a/src/app/projects/[pid]/manage/page.tsx
+++ b/src/app/projects/[pid]/manage/page.tsx
@@ -187,6 +187,37 @@ export default function ManageApplicantsPage() {
                 </div>
               </div>
               <div className="flex justify-end gap-2 mt-4">
+                {/* ✨ 대화하기 버튼 (면접/인터뷰) */}
+                <button
+                  onClick={async () => {
+                    try {
+                      const res = await fetch('/api/chat/rooms', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                          category: 'RECRUIT',
+                          participants: [app.applicantId._id],
+                          applicationId: app._id,
+                          projectId: project._id, // 🔥 프로젝트의 실제 ObjectId (_id)로 수정
+                        }),
+                      });
+                      const data = await res.json();
+                      if (data.success) {
+                        router.push(`/chat?roomId=${data.data._id}`);
+                      } else {
+                        const errorMsg = data.error ? `${data.message}\n(${data.error})` : (data.message || '채팅방 생성 실패');
+                        await alert('오류', errorMsg);
+                      }
+                    } catch (e: any) {
+                      await alert('오류', `요청 중 문제가 발생했습니다.\n${e.message}`);
+                    }
+                  }}
+                  className="px-3 py-1 text-sm bg-blue-100 text-blue-600 rounded hover:bg-blue-200 transition-colors flex items-center gap-1"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
+                  대화하기
+                </button>
+
                 {app.status === 'pending' && (
                   <>
                     <button onClick={() => handleStatusChange(app._id, 'accepted')} className="px-3 py-1 text-sm bg-green-500 text-white rounded hover:bg-green-600 transition-colors">수락</button>


### PR DESCRIPTION
- 프로젝트 상세 페이지: '문의하기(INQUIRY)' 버튼 및 기능 구현
- 지원자 관리 페이지: '대화하기(RECRUIT)' 버튼 및 기능 구현
- 팀 대시보드 페이지: '팀 채팅(TEAM)' 버튼 및 기능 구현
- 임시 채팅 페이지: 라우팅 테스트용 `/chat` 페이지 생성
- fix: 채팅방 생성 시 projectId 타입 불일치(String -> ObjectId) 버그 수정