### PR TITLE
feat(chat): [Phase 3] 채팅 카테고리 시각화(UI/UX) 구현 고도화 (#109)

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,14 +1,49 @@
 'use client';
 
-// 🚧 [임시 페이지] 채팅 기능 구현 전 라우팅 테스트용 페이지
+import { useState } from 'react';
+import ChatRoomList, { MockChatRoom } from '@/components/chat/ChatRoomList';
+import ChatWindow from '@/components/chat/ChatWindow';
+
+// 🧪 UI 테스트를 위한 가짜(Mock) 데이터 셋이야.
+const MOCK_ROOMS: MockChatRoom[] = [
+    { _id: 'room_1', category: 'INQUIRY', title: '사이드프로젝트 관련 문의사항 남깁니다.', lastMessage: '안녕하세요, 혹시 포트폴리오 필수인가요?', updatedAt: new Date().toISOString() },
+    { _id: 'room_2', category: 'RECRUIT', title: '프론트엔드 지원자 프론찌님 인터뷰', lastMessage: '네, 내일 오후 3시 좋을 것 같습니다!', updatedAt: new Date(Date.now() - 1000 * 60 * 30).toISOString() },
+    { _id: 'room_3', category: 'TEAM', title: '🔥 [SPM] 어벤져스 팀 공식 채팅방', lastMessage: '회의록 노션에 정리해서 올렸습니다~ 확인 부탁드려요!', updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString() },
+    { _id: 'room_4', category: 'DM', title: '프론찌 (프론트엔드)', lastMessage: '다음에 또 같이 프로젝트 하면 좋겠네요 ㅎㅎ', updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString() },
+    { _id: 'room_5', category: 'SYSTEM', title: '가이드 봇', lastMessage: '환영합니다! 프로젝트 설정을 완료해 보세요.', updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString() },
+];
+
 export default function ChatPage() {
+    // 현재 선택된 채팅방의 상태 관리를 위한 훅이야.
+    const [activeRoomId, setActiveRoomId] = useState<string>(MOCK_ROOMS[0]._id);
+
     return (
-        <div className="flex items-center justify-center min-h-screen bg-slate-100">
-            <div className="text-center">
-                <h1 className="text-4xl font-bold text-slate-800 mb-4">💬 채팅 페이지</h1>
-                <p className="text-slate-600">아직 채팅 기능이 구현되지 않았습니다.</p>
-                <p className="text-slate-500 text-sm mt-2">Phase 3에서 UI가 구현될 예정입니다.</p>
+        <div className="flex h-[calc(100vh-64px)] bg-slate-100 overflow-hidden">
+            {/* 좌측 사이드바: 채팅방 리스트 영역 (Step 3.2 UI 적용) */}
+            <div className="w-80 bg-white border-r border-slate-200 flex flex-col shadow-sm z-10">
+                <div className="p-4 border-b border-slate-100">
+                    <h2 className="text-lg font-bold text-slate-800">메시지</h2>
+                </div>
+                {/* 📝 방금 만든 리스트 컴포넌트 렌더링! */}
+                <ChatRoomList
+                    rooms={MOCK_ROOMS}
+                    activeRoomId={activeRoomId}
+                    onRoomClick={(id) => setActiveRoomId(id)}
+                />
             </div>
+
+            {/* 우측 메인: 채팅 대화창 영역 (Step 3.3 구현 적용) */}
+            {MOCK_ROOMS.find(r => r._id === activeRoomId) ? (
+                <ChatWindow room={MOCK_ROOMS.find(r => r._id === activeRoomId)!} />
+            ) : (
+                <div className="flex-1 flex flex-col items-center justify-center bg-slate-50/50">
+                    <div className="text-center text-slate-400">
+                        <svg className="w-16 h-16 mx-auto mb-4 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
+                        <p className="text-lg font-medium text-slate-600 mb-1">선택된 대화가 없습니다.</p>
+                        <p className="text-sm">왼쪽에서 채팅방을 선택해 주세요.</p>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/chat/ChatRoomList.tsx
+++ b/src/components/chat/ChatRoomList.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { getCategoryColor, ChatCategory } from '@/constants/chat';
+
+// 💡 임시 인터페이스: 백엔드 API 연동 전에 UI를 작성하기 위한 Mock 데이터 타입이야.
+export interface MockChatRoom {
+    _id: string;
+    category: ChatCategory;
+    title: string;
+    lastMessage?: string;
+    updatedAt: string;
+}
+
+interface ChatRoomListProps {
+    rooms: MockChatRoom[];
+    activeRoomId?: string;
+    onRoomClick: (roomId: string) => void;
+}
+
+/**
+ * 🎨 채팅방 리스트를 보여주는 컴포넌트야.
+ * Step 3.2 요구사항에 맞춰서 각 아이템 왼쪽에 카테고리별 색상 인디케이터(세로 바)를 추가했어!
+ */
+export default function ChatRoomList({ rooms, activeRoomId, onRoomClick }: ChatRoomListProps) {
+    if (rooms.length === 0) {
+        return (
+            <div className="flex flex-col items-center justify-center h-full text-slate-400 p-4 text-center">
+                <p>아직 참여 중인 대화가 없습니다.</p>
+                <p className="text-sm mt-1">프로젝트에 지원하거나 팀원들에게 메시지를 보내보세요!</p>
+            </div>
+        );
+    }
+
+    return (
+        <ul className="divide-y divide-slate-100 flex-1 overflow-y-auto">
+            {rooms.map((room) => {
+                const categoryColor = getCategoryColor(room.category);
+                const isActive = room._id === activeRoomId;
+
+                return (
+                    <li
+                        key={room._id}
+                        onClick={() => onRoomClick(room._id)}
+                        // 🖱️ 호버 효과와 현재 활성화된 방 스타일을 다르게 줘서 UX를 높였어.
+                        className={`
+                            relative cursor-pointer transition-colors p-4
+                            hover:bg-slate-50
+                            ${isActive ? 'bg-slate-50' : 'bg-white'}
+                        `}
+                    >
+                        {/* 🌈 카테고리 컬러 인디케이터 (왼쪽 세로 바) */}
+                        <div
+                            className="absolute left-0 top-0 bottom-0 w-1.5"
+                            style={{ backgroundColor: categoryColor }}
+                        />
+
+                        <div className="pl-2">
+                            <div className="flex items-center justify-between mb-1">
+                                <h3 className="font-semibold text-slate-800 text-sm truncate pr-2">
+                                    {room.title}
+                                </h3>
+                                {/* 🏷️ 카테고리 배지 (우측 상단) */}
+                                <span
+                                    className="text-[10px] font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
+                                    style={{
+                                        // 배경은 연하게, 글씨는 진하게 처리해서 가독성을 높여주는 센스!
+                                        backgroundColor: `${categoryColor}20`, // Hex 테일윈드에서 20(Hex opacity)을 추가해서 투명도 12% 정도 적용
+                                        color: categoryColor,
+                                    }}
+                                >
+                                    {room.category}
+                                </span>
+                            </div>
+
+                            <div className="flex items-center justify-between text-xs text-slate-500 mt-1">
+                                <p className="truncate pr-4 flex-1">
+                                    {room.lastMessage || '새로운 채팅방이 생성되었습니다.'}
+                                </p>
+                                <span className="whitespace-nowrap shrink-0">
+                                    {new Date(room.updatedAt).toLocaleTimeString('ko-KR', {
+                                        hour: '2-digit',
+                                        minute: '2-digit',
+                                    })}
+                                </span>
+                            </div>
+                        </div>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { getCategoryColor } from '@/constants/chat';
+import { MockChatRoom } from './ChatRoomList';
+
+interface ChatWindowProps {
+    room: MockChatRoom;
+}
+
+/**
+ * 💬 채팅 대화창 컴포넌트야.
+ * Step 3.3 요구사항에 맞춰서 활성화된 채팅방 카테고리에 따라 상단(Header)의 테마를 변경하고 있어!
+ */
+export default function ChatWindow({ room }: ChatWindowProps) {
+    const categoryColor = getCategoryColor(room.category);
+
+    return (
+        <div className="flex-1 flex flex-col bg-slate-50/50 relative">
+            {/* 
+              🌟 상단 헤더 영역 (Step 3.3 핵심 구현 부분)
+              - top border 박스로 컬러 라인을 명확하게 줬어!
+              - 배경색에도 살짝 투명도를 넣어서 대화방 성격을 은은하게 인지하도록 만들었지.
+            */}
+            <div
+                className="flex items-center justify-between p-4 bg-white shadow-sm z-10 border-t-4"
+                style={{
+                    borderTopColor: categoryColor,
+                    // 배경에 아주 연하게(약 3% 불투명도) 카테고리 색상을 깔아서 분위기를 맞춤
+                    backgroundColor: `color-mix(in srgb, ${categoryColor} 3%, white)`
+                }}
+            >
+                <div>
+                    <div className="flex items-center gap-2 mb-1">
+                        {/* 📛 헤더에도 배지를 배치해서 현재 어떤 성격의 대화인지 확실히 각인! */}
+                        <span
+                            className="text-xs font-bold px-2 py-0.5 rounded-md"
+                            style={{
+                                backgroundColor: categoryColor,
+                                color: 'white' // 여긴 눈에 띄게 흰 글씨로!
+                            }}
+                        >
+                            {room.category}
+                        </span>
+                        <h2 className="text-lg font-bold text-slate-800">{room.title}</h2>
+                    </div>
+                </div>
+
+                {/* 우측 도구 모음 (추후 구현 예정) */}
+                <div className="flex items-center gap-3 text-slate-400">
+                    <button className="hover:text-slate-600 transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+                    </button>
+                    <button className="hover:text-slate-600 transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
+                    </button>
+                </div>
+            </div>
+
+            {/* 메인 채팅 내역 영역 (추후 무한 스크롤 및 메시지 버블 구현 예정) */}
+            <div className="flex-1 overflow-y-auto p-6 space-y-4">
+                {/* 봇 안내 메시지 예시 (시스템 카테고리인 경우 보여주기 좋음) */}
+                <div className="flex justify-center my-4">
+                    <span className="text-xs text-slate-400 bg-slate-100 px-3 py-1 rounded-full">
+                        대화가 시작되었습니다.
+                    </span>
+                </div>
+
+                {/* 임시 메시지 버블 */}
+                <div className="flex items-start gap-3">
+                    <div className="w-8 h-8 rounded-full bg-slate-200 shrink-0" />
+                    <div className="flex flex-col gap-1 items-start">
+                        <span className="text-xs text-slate-500 ml-1">상대방</span>
+                        <div className="bg-white p-3 rounded-2xl rounded-tl-sm shadow-sm border border-slate-100 max-w-md">
+                            <p className="text-slate-700 text-sm leading-relaxed">{room.lastMessage || '안녕하세요!'}</p>
+                        </div>
+                        <span className="text-[10px] text-slate-400 ml-1">오후 2:30</span>
+                    </div>
+                </div>
+            </div>
+
+            {/* 채팅 입력창 영역 */}
+            <div className="p-4 bg-white border-t border-slate-200">
+                <div className="flex items-center gap-2 bg-slate-50 border border-slate-200 rounded-full px-4 py-2 focus-within:ring-1 focus-within:ring-slate-300 transition-shadow">
+                    <button className="text-slate-400 hover:text-slate-600 transition-colors p-1">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
+                    </button>
+                    <input
+                        type="text"
+                        placeholder="메시지를 입력하세요..."
+                        className="flex-1 bg-transparent border-none focus:outline-none text-sm text-slate-700 px-2"
+                    />
+                    <button
+                        className="bg-slate-800 text-white p-1.5 rounded-full hover:bg-slate-700 transition-colors flex shrink-0 items-center justify-center h-8 w-8"
+                    >
+                        <svg className="w-4 h-4 translate-x-[-1px] translate-y-[1px]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" /></svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -1,0 +1,35 @@
+/**
+ * 채팅 시스템에서 사용되는 카테고리 타입 정의입니다.
+ * 💡 왜 타입을 먼저 선언할까?
+ * TypeScript에서는 우리가 어떤 category 값을 받을지 명확히 해두어야 자동완성(IntelliSense)도 잘 되고 오타로 인한 버그를 미리 막을 수 있어!
+ */
+export type ChatCategory = 'INQUIRY' | 'RECRUIT' | 'TEAM' | 'DM' | 'SYSTEM';
+
+/**
+ * 프로젝트에서 정의된 채팅 카테고리별 테마 색상(Hex) 객체입니다.
+ * 색상 변경이 필요할 때 여기만 수정하면 전체 채팅 UI에 한 번에 적용돼! 유지보수를 위한 아주 중요한 패턴이야.
+ */
+export const CHAT_CATEGORY_COLORS: Record<ChatCategory, string> = {
+    INQUIRY: '#FFD93D', // 노랑 - 프로젝트 단순 문의
+    RECRUIT: '#6BCB77', // 초록 - 지원 및 인터뷰
+    TEAM: '#4D96FF',    // 파랑 - 팀 협업 (매칭 완료)
+    DM: '#FF6B6B',      // 빨강 - 개인 소셜 메시지
+    SYSTEM: '#95A5A6',  // 회색 - 시스템 공지/가이드
+};
+
+/**
+ * 카테고리(category) 문자열을 입력받아서 해당하는 색상(Hex)을 반환하는 유틸리티 함수야.
+ * 만약 정의되지 않은 카테고리가 들어오면 안전하게 기본 색상(회색)을 반환해줘!
+ * 
+ * @param category 채팅방의 카테고리 분류 (예: 'TEAM', 'DM' 등)
+ * @returns {string} 매핑된 색상의 Hex 코드
+ */
+export const getCategoryColor = (category: ChatCategory | string): string => {
+    // 1️⃣ 입력된 카테고리가 무조건 ChatCategory 키값 안에 있는지 판별해.
+    // 2️⃣ 일치하는 키값이 있다면 해당하는 색상 코드를 반환하고, 아니면 SYSTEM의 기본 회색 코드를 반환하도록 방어 로직을 작성했지!
+    if (category in CHAT_CATEGORY_COLORS) {
+        return CHAT_CATEGORY_COLORS[category as ChatCategory];
+    }
+    // 예외 처리: 예상치 못한 값이 들어왔을 때는 기본값을 반환해서 UI가 깨지지 않는 게 중요해.
+    return CHAT_CATEGORY_COLORS.SYSTEM;
+};


### PR DESCRIPTION
feat(chat): [Phase 3] 채팅 카테고리 시각화(UI/UX) 구현 고도화 (#109)
- feat: 카테고리별 테마 색상(Hex) 정의 및 [getCategoryColor] 유틸리티 함수 추가
- feat: 채팅방 목록([ChatRoomList]카테고리 컬러 바(Indicator) 및 반투명 배지 UI 적용
- feat: 대화창([ChatWindow]헤더에 카테고리 동적 테마(Border Color, Background Tint) 연동
- chore: UI 디자인 테스트를 위한 임시 라우터 페이지 구성 및 Mock Data 연동
* 적용된 컬러 스키마:
  - INQUIRY (노랑): #FFD93D
  - RECRUIT (초록): #6BCB77
  - TEAM (파랑): #4D96FF
  - DM (빨강): #FF6B6B
  - SYSTEM (회색): #95A5A6