### PR TITLE
fix(board): 칸반보드 실시간 접속자(Presence) 동기화 오류 현상 복구 및 아바타 이미지 연동

### DIFF
--- a/src/components/board/ShortcutModal.tsx
+++ b/src/components/board/ShortcutModal.tsx
@@ -8,7 +8,7 @@ type Shortcut = {
 const SHORTCUTS: Shortcut[] = [
     // View
     { key: 'Drag BG', description: '화면 이동 (Pan)' },
-    { key: 'Alt + Wheel', description: '줌 확대/축소' },
+    { key: 'Mouse Wheel', description: '줌 확대/축소' },
     { key: 'Shift + 1', description: '전체 화면 맞춤 (Fit)' },
 
     // Selection

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,6 +25,7 @@ export const authOptions: NextAuthOptions = {
             _id: user._id.toString(),
             email: user.authorEmail,
             name: user.nName,
+            image: user.avatarUrl,
           };
         } else {
           throw new Error('이메일 또는 비밀번호가 일치하지 않습니다.');


### PR DESCRIPTION
[원인 및 작업 내용]
1. 서버 사이드 소켓 이벤트 누락 복구 (server.ts)
- 클라이언트에서 방 접속 시 발생하는 `user-activity`, `leave-board` 이벤트를 수신하는 서버 핸들러가 누락되어 있던 문제 해결.
- `boardUsers` 와 `socketUserMap` 자료구조를 추가하여 칸반보드 접속자 상태(Presence) 캐싱.
- 사용자가 속한 방(Room)에 `board-users-update` 이벤트를 브로드캐스트하여 실시간 다중 접속자 목록 동기화 처리.
- 브라우저 비정상 종료를 대비한 `disconnect` 이벤트 내 Presence 퇴장 핸들링 로직 추가.

2. 클라이언트 비반응형 상태 참조 오류 수정 (BoardShell.tsx)
- 보드 렌더링 초기 시점([initBoard](cci:1://file:///c:/workspace/sideProjectMate/src/store/boardStore.ts:160:8-206:9) 완료 전)에 `useBoardStore.getState().boardId`가 `null`인 상태로 고정되어 소켓 이벤트가 발생하지 않던 문제 해결.
- Zustand store에서 `boardId`와 [initSocket](cci:1://file:///c:/workspace/sideProjectMate/src/store/boardStore.ts:223:8-342:9)을 직접 스코프 단위로 가져와 `useEffect`의 의존성(Dependencies) 배열에 추가. API 이후 값이 변할 때 반응(Reactive)하여 정상적으로 소켓 초기화가 이루어지도록 리팩토링.

3. NextAuth 세션 프로필 사진(Avatar) 속성 매핑 (auth.ts)
- 실시간 접속자 UI에서 이니셜만 표출되는 현상 수정.
- NextAuth의 `CredentialsProvider` 인증 과정(authorize) 중, MongoDB에서 조회한 사용자의 `avatarUrl` 값을 `image` 속성에 병합하여 세션 객체로 반환.
- 클라이언트의 `useSession` 내 `session.user.image` 필드와 소켓 초기화 데이터가 연동되어 화면에 정상적으로 사용자 프로필 사진이 노출되도록 보완.