### PR TITLE
feat(chat): [Phase 5] 실시간 채팅 레이어 구축 및 소켓 연결 연동 (#110)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -224,6 +224,23 @@ app.prepare().then(() => {
 
 
         // ------------------------------------------------------------
+        // [Part 3] SPM 실시간 채팅 로직 (Phase 5)
+        // ------------------------------------------------------------
+
+        // 1. 채팅방 접속 (Room Join)
+        socket.on('join-chat-room', ({ roomId, userId }) => {
+            // 채팅방 ID 전용 네임스페이스처럼 사용
+            const chatRoomKey = `chat-${roomId}`;
+            socket.join(chatRoomKey);
+            console.log(`[Chat] User ${userId} joined room: ${roomId}`);
+        });
+
+        // 2. 채팅방 이탈 (Room Leave)
+        socket.on('leave-chat-room', ({ roomId, userId }) => {
+            const chatRoomKey = `chat-${roomId}`;
+            socket.leave(chatRoomKey);
+            console.log(`[Chat] User ${userId} left room: ${roomId}`);
+        });
         // [Common] 연결 해제 처리 (공통)
         // ------------------------------------------------------------
         socket.on('disconnect', () => {

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -2,6 +2,7 @@
 
 import { getCategoryColor } from '@/constants/chat';
 import { MockChatRoom } from './ChatRoomList';
+import { useChatSocket } from '@/hooks/useChatSocket';
 
 interface ChatWindowProps {
     room: MockChatRoom;
@@ -13,6 +14,10 @@ interface ChatWindowProps {
  */
 export default function ChatWindow({ room }: ChatWindowProps) {
     const categoryColor = getCategoryColor(room.category);
+
+    // 🔌 Step 5.2: 해당 채팅방에 입장하면서 소켓 연결하기
+    // useChatSocket 훅 내부의 useEffect가 roomId가 바뀔 때마다 기존 방에서 나가고 새 방으로 입장(join)하도록 처리해줘.
+    const { isConnected } = useChatSocket(room._id);
 
     return (
         <div className="flex-1 flex flex-col bg-slate-50/50 relative">
@@ -53,6 +58,11 @@ export default function ChatWindow({ room }: ChatWindowProps) {
                     <button className="hover:text-slate-600 transition-colors">
                         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
                     </button>
+                    {/* 디버깅용 실시간 연결 상태 표시기 (우측 상단 점) */}
+                    <div
+                        className={`w-2.5 h-2.5 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-400'}`}
+                        title={isConnected ? '실시간 통신 연결됨' : '연결 끊김'}
+                    />
                 </div>
             </div>
 

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState, useCallback } from 'react';
+import { getSocket, disconnectSocket } from '@/lib/socket';
+import { Socket } from 'socket.io-client';
+
+export const useChatSocket = (roomId?: string) => {
+    const [socket, setSocket] = useState<Socket | null>(null);
+    const [isConnected, setIsConnected] = useState(false);
+
+    useEffect(() => {
+        // 1. 소켓 인스턴스 가져오기 (없으면 새로 연결됨)
+        const socketInstance = getSocket();
+        setSocket(socketInstance);
+        setIsConnected(socketInstance.connected);
+
+        // 2. 기본 연결 이벤트 리스너 세팅
+        const onConnect = () => setIsConnected(true);
+        const onDisconnect = () => setIsConnected(false);
+
+        socketInstance.on('connect', onConnect);
+        socketInstance.on('disconnect', onDisconnect);
+
+        // 3. 특정 방(roomId)이 주어지면 방에 입장 (Join Room)
+        if (roomId) {
+            // 임시로 userId를 넘겨주는 로직 (추후 session 객체 등에서 가져와 실제 ID 연동 필요)
+            // 현재 단계에선 단순히 소켓 서버에 '나 들어왔다'고 알림
+            socketInstance.emit('join-chat-room', { roomId, userId: 'temp_user_id' });
+        }
+
+        // 4. 클린업 (컴포넌트 언마운트 시)
+        return () => {
+            if (roomId) {
+                socketInstance.emit('leave-chat-room', { roomId, userId: 'temp_user_id' });
+            }
+
+            socketInstance.off('connect', onConnect);
+            socketInstance.off('disconnect', onDisconnect);
+
+            // 다른 곳(헤더나 보드 등)에서 소켓을 쓰고 있을 수 있으므로 
+            // 컴포넌트 언마운트 시 무조건 disconnectSocket()을 호출하면 안됨.
+            // 필요하다면 전역 소켓 관리 로직을 더 정교하게 다듬어야 함.
+        };
+    }, [roomId]);
+
+    // 외부 컴포넌트에서 이벤트를 구독하거나 해제할 수 있는 헬퍼 함수
+    const subscribe = useCallback((event: string, callback: (...args: any[]) => void) => {
+        if (!socket) return;
+        socket.on(event, callback);
+        return () => {
+            socket.off(event, callback);
+        };
+    }, [socket]);
+
+    const emit = useCallback((event: string, data: any) => {
+        if (!socket) return;
+        socket.emit(event, data);
+    }, [socket]);
+
+    return { socket, isConnected, subscribe, emit };
+};


### PR DESCRIPTION
feat(chat): [Phase 5] 실시간 채팅 레이어 구축 및 소켓 연결 연동 (#110)
- feat: 기존 협업용 소켓 서버 환경에 안전하게 채팅 전용 룸(Room) 접속 및 이탈 시스템 통합 추가
- feat: 실시간 통신 라이프사이클(연결/해제/구독)을 자동으로 관리하는 전용 채팅 매니저 훅(Hook) 연동
- refactor: 대화창 진입 및 이탈 시 실시간 채널에 자동으로 연결/해제되도록 접속 흐름 개선
- design: 대화창 헤더에 유저가 실시간 통신 상태를 직관적으로 확인할 수 있는 인디케이터(🟢/🔴) UI 추가
close #117 