### PR TITLE
perf(kanban): 칸반 보드 소켓 리스너 누수 수정 및 드래그 성능 개선

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -115,6 +115,12 @@ app.prepare().then(() => {
             socket.to(boardId).emit('note-deleted', noteId);
         });
 
+        // 4-1. 노트 배치 삭제
+        socket.on('delete-notes-batch', (data) => {
+            const { boardId, noteIds } = data;
+            socket.to(boardId).emit('notes-deleted-batch', noteIds);
+        });
+
         // 5. 섹션 업데이트
         socket.on('update-section', (data) => {
             const { boardId, section } = data;

--- a/src/components/board/BoardShell.tsx
+++ b/src/components/board/BoardShell.tsx
@@ -124,6 +124,24 @@ const BoardShell: React.FC<Props> = ({ pid }) => {
 
       return () => {
         socketClient.socket?.emit('leave-board', { boardId, userId: session.user.id });
+        const socket = socketClient.socket;
+        if (socket) {
+          socket.off('note-created');
+          socket.off('note-updated');
+          socket.off('note-deleted');
+          socket.off('notes-deleted-batch');
+          socket.off('note-locked');
+          socket.off('note-unlocked');
+          socket.off('section-locked');
+          socket.off('section-unlocked');
+          socket.off('section-created');
+          socket.off('section-updated');
+          socket.off('section-deleted');
+          socket.off('note-selected');
+          socket.off('note-deselected');
+          socket.off('board-synced');
+          socket.off('board-users-update');
+        }
       };
     }
   }, [boardPid, session, boardId, initSocket]);
@@ -284,7 +302,8 @@ const BoardShell: React.FC<Props> = ({ pid }) => {
         isDragOccurred.current = true;
       }
 
-      setPan(pan.x + dx, pan.y + dy);
+      const { pan: currentPan } = useBoardStore.getState();
+      setPan(currentPan.x + dx, currentPan.y + dy);
       lastPanRef.current = { x: e.clientX, y: e.clientY };
     }
   };

--- a/src/store/boardStore.ts
+++ b/src/store/boardStore.ts
@@ -252,6 +252,11 @@ export const useBoardStore = create<BoardState>()(
             get().applyRemoteNoteDeletion(noteId);
           });
 
+          socket.off('notes-deleted-batch');
+          socket.on('notes-deleted-batch', (noteIds: string[]) => {
+            noteIds.forEach(noteId => get().applyRemoteNoteDeletion(noteId));
+          });
+
           // Lock Events
           socket.off('note-locked');
           socket.on('note-locked', (data: { id: string; userId: string; socketId: string }) => {
@@ -456,9 +461,7 @@ export const useBoardStore = create<BoardState>()(
 
             if (boardId) {
               const socket = socketClient.connect();
-              ids.forEach(id => {
-                socket.emit('delete-note', { boardId: boardId!, noteId: id });
-              });
+              socket.emit('delete-notes-batch', { boardId, noteIds: ids });
             }
           } catch (error) {
             console.error(error);


### PR DESCRIPTION
[REF-7] BoardShell.tsx — 언마운트 시 소켓 리스너 미해제 수정
- useEffect cleanup에서 note-created/updated/deleted, section-*, note-selected 등 initSocket에서 등록된 이벤트 리스너 15개 전부 socket.off() 처리
- 싱글톤 소켓이 다른 페이지로 이동해도 리스너가 살아있던 메모리 누수 해결

[PERF-4] BoardShell.tsx — 빠른 패닝 시 스테일 pan 값 수정
- setPan(pan.x + dx) → useBoardStore.getState().pan으로 항상 최신 값 참조
- 빠른 패닝 중 렌더 전 다수 이벤트 누적 시 발생하던 위치 오차 해결

[PERF-5] server.ts + boardStore.ts — 배치 삭제 Socket 이벤트화
- removeNotes에서 N번 개별 delete-note emit → delete-notes-batch 1회 emit으로 변경
- server.ts에 delete-notes-batch / notes-deleted-batch 이벤트 핸들러 추가
- initSocket에 notes-deleted-batch 수신 리스너 추가

[PERF-2] NoteItem.tsx — 다중 노트 드래그 DOM 캐싱
- 드래그 시작 시 선택된 노트의 DOM 요소와 시작 위치를 nodeCacheRef에 1회 캐싱
- 매 pointerMove마다 N회 querySelector + 정규식 파싱 → Map 순회로 대체
- 시작 위치 + 누적 delta(totalDragRef)로 정확도도 향상

[PERF-3] SectionItem.tsx — 섹션 드래그 자식 노트 DOM 캐싱
- 드래그 시작 시 자식 노트 DOM 요소와 시작 위치를 childNodeCacheRef에 1회 캐싱
- 매 pointerMove마다 querySelectorAll + 정규식 파싱 → Map 순회 + 누적 delta로 대체