### PR TITLE
feat: P1 UI 전반 개선 - 브랜드 컬러, 헤더/푸터 개편, 인증 페이지 리디자인, 공통 컴포넌트 신설

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,10 +4,21 @@
 
 @layer base {
   :root {
-    /* 
+    /*
       Semantic Colors (시맨틱 컬러) 정의
       Tailwind Config와 연결되어 사용됩니다.
     */
+
+    /* === 브랜드 컬러 (인디고 계열) === */
+    --brand: #4f46e5;
+    /* indigo-600 */
+    --brand-hover: #4338ca;
+    /* indigo-700 */
+    --brand-light: #e0e7ff;
+    /* indigo-100 */
+    --brand-foreground: #ffffff;
+
+    /* === 배경 / 텍스트 === */
     --background: #ffffff;
     --foreground: #111827;
     /* gray-900 */
@@ -18,11 +29,13 @@
     --popover: #ffffff;
     --popover-foreground: #111827;
 
-    --primary: #1f2937;
-    /* gray-800 */
+    /* === 버튼 Primary = 브랜드 컬러 === */
+    --primary: #4f46e5;
+    --primary-hover: #4338ca;
     --primary-foreground: #ffffff;
 
-    --secondary: #ffffff;
+    --secondary: #f3f4f6;
+    /* gray-100 */
     --secondary-foreground: #374151;
     /* gray-700 */
 
@@ -35,15 +48,16 @@
     /* gray-50 */
     --accent-foreground: #111827;
 
+    /* destructive — light/dark 모두 선명하게 */
     --destructive: #ef4444;
     /* red-500 */
+    --destructive-hover: #dc2626;
+    /* red-600 */
     --destructive-foreground: #ffffff;
 
-    --border: rgba(164, 164, 164, 0.814);
-    /* Modern Subtle Gray */
-    --input: rgba(164, 164, 164, 0.814);
-    --ring: #111827;
-    /* gray-900 */
+    --border: rgba(156, 163, 175, 0.6);
+    --input: rgba(156, 163, 175, 0.6);
+    --ring: #4f46e5;
   }
 
   .dark {
@@ -59,12 +73,14 @@
     --popover: #1f2937;
     --popover-foreground: #f3f4f6;
 
-    --primary: #374151;
-    /* gray-700 */
+    /* 다크모드에서도 브랜드 컬러 유지 */
+    --primary: #6366f1;
+    /* indigo-500 (살짝 밝게) */
+    --primary-hover: #4f46e5;
+    /* indigo-600 */
     --primary-foreground: #ffffff;
 
     --secondary: #1f2937;
-    /* gray-800 */
     --secondary-foreground: #d1d5db;
     /* gray-300 */
 
@@ -74,59 +90,118 @@
     /* gray-400 */
 
     --accent: #1f2937;
-    /* gray-800 */
     --accent-foreground: #f3f4f6;
 
-    --destructive: #7f1d1d;
-    /* red-900 */
-    --destructive-foreground: #f3f4f6;
+    /* destructive — dark에서도 동일하게 선명히 */
+    --destructive: #ef4444;
+    --destructive-hover: #dc2626;
+    --destructive-foreground: #ffffff;
 
-    --border: rgba(164, 164, 164, 0.814);
-    /* Modern Subtle White */
-    --input: rgba(164, 164, 164, 0.814);
-    --ring: #d1d5db;
-    /* gray-300 */
+    --border: rgba(156, 163, 175, 0.25);
+    --input: rgba(156, 163, 175, 0.25);
+    --ring: #6366f1;
   }
 
+  /* === Pretendard 폰트 === */
   @font-face {
     font-family: 'Pretendard';
     font-weight: 400;
     font-display: swap;
-    src: local('Pretendard'), url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+    src: local('Pretendard'),
+      url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
   }
 
   @font-face {
     font-family: 'Pretendard';
     font-weight: 600;
     font-display: swap;
-    src: local('Pretendard'), url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff') format('woff');
+    src: local('Pretendard'),
+      url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff') format('woff');
   }
 
   @font-face {
     font-family: 'Pretendard';
     font-weight: 700;
     font-display: swap;
-    src: local('Pretendard'), url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff') format('woff');
+    src: local('Pretendard'),
+      url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff') format('woff');
   }
 
   body {
     @apply bg-background text-foreground font-sans transition-colors duration-200;
   }
+
+  /* 기본 focus outline 스타일 */
+  :focus-visible {
+    @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
+  }
 }
 
 @layer components {
+
+  /* === 버튼 === */
+  /* @apply 안에서 CSS 변수 색상에 /opacity 수정자를 쓰면 오류 발생.
+     hover 상태는 brightness 필터 또는 별도 CSS 변수로 처리합니다. */
   .btn-primary {
-    @apply px-6 py-2.5 bg-gray-800 dark:bg-gray-700 text-white rounded-lg font-semibold hover:bg-gray-900 dark:hover:bg-gray-600 transition-colors duration-200;
+    @apply inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold bg-primary text-primary-foreground active:scale-[0.98] transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background-color: var(--primary-hover);
   }
 
   .btn-secondary {
-    @apply px-6 py-2.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg font-semibold hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200;
+    @apply inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold bg-secondary text-secondary-foreground border border-border hover:bg-muted active:scale-[0.98] transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
+  .btn-destructive {
+    @apply inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold bg-destructive text-destructive-foreground active:scale-[0.98] transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+
+  .btn-destructive:hover:not(:disabled) {
+    background-color: var(--destructive-hover);
+  }
+
+  .btn-ghost {
+    @apply inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-all duration-150;
+  }
+
+  /* === 폼 인풋 === */
+  .form-input {
+    @apply w-full px-3 py-2.5 rounded-lg border border-input bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+
+  .form-label {
+    @apply block text-sm font-medium text-foreground mb-1.5;
+  }
+
+  /* === 카드 === */
   .card {
-    @apply bg-white dark:bg-gray-800 rounded-xl shadow-sm hover:shadow-md transition-shadow duration-200 overflow-hidden;
+    @apply bg-card text-card-foreground rounded-xl border border-border shadow-sm hover:shadow-md transition-shadow duration-200;
   }
 
+  /* === 배지 === */
+  .badge {
+    @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold;
+  }
+
+  .badge-primary {
+    @apply badge bg-brand-light text-brand;
+  }
+
+  .badge-success {
+    @apply badge bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300;
+  }
+
+  .badge-warning {
+    @apply badge bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300;
+  }
+
+  .badge-danger {
+    @apply badge bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300;
+  }
+
+  /* === 스크롤바 숨김 === */
   .scrollbar-hide {
     -ms-overflow-style: none;
     scrollbar-width: none;
@@ -134,5 +209,40 @@
 
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
+  }
+}
+
+@layer utilities {
+
+  /* 토스트 슬라이드 애니메이션 */
+  @keyframes slide-in-up {
+    from {
+      opacity: 0;
+      transform: translateY(1rem);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .animate-slide-in-up {
+    animation: slide-in-up 0.25s ease-out forwards;
+  }
+
+  /* 페이드 인 */
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+
+  .animate-fade-in {
+    animation: fade-in 0.2s ease-out forwards;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,16 +3,26 @@ import { Inter } from 'next/font/google'
 import './globals.css'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
-import FloatingThemeButton from '@/components/FloatingThemeButton'
 import { ThemeProvider } from '@/components/ThemeProvider'
 import AuthSessionProvider from '@/components/AuthSessionProvider'
 import GlobalModal from '@/components/common/GlobalModal'
+import Toast from '@/components/common/Toast'
 
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Side Project Mate',
-  description: '디자이너, 기획자, 개발자를 위한 사이드 프로젝트 매칭 플랫폼',
+  title: {
+    default: 'Side Project Mate',
+    template: '%s | Side Project Mate',
+  },
+  description: '디자이너, 기획자, 개발자를 위한 사이드 프로젝트 팀 매칭 플랫폼',
+  openGraph: {
+    title: 'Side Project Mate',
+    description: '디자이너, 기획자, 개발자를 위한 사이드 프로젝트 팀 매칭 플랫폼',
+    siteName: 'Side Project Mate',
+    locale: 'ko_KR',
+    type: 'website',
+  },
 }
 
 export default function RootLayout({
@@ -31,8 +41,10 @@ export default function RootLayout({
                 {children}
               </main>
               <Footer />
-              <FloatingThemeButton />
+              {/* 전역 모달 */}
               <GlobalModal />
+              {/* 전역 Toast (FloatingThemeButton 제거 후 Toast로 대체) */}
+              <Toast />
             </div>
           </ThemeProvider>
         </AuthSessionProvider>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
+import Link from 'next/link';
 
 export default function LoginPage() {
   const [formData, setFormData] = useState({
@@ -11,13 +12,11 @@ export default function LoginPage() {
   });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const router = useRouter();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value,
-    });
+    setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -27,90 +26,168 @@ export default function LoginPage() {
 
     try {
       const result = await signIn('credentials', {
-        redirect: false, // 페이지 새로고침 방지
+        redirect: false,
         authorEmail: formData.authorEmail,
         password: formData.password,
       });
 
       if (result?.ok) {
-        // 로그인 성공 시 홈으로 이동
         router.push('/');
       } else {
-        // 로그인 실패 시 에러 메시지 설정
-        setError(result?.error || '로그인에 실패했습니다.');
+        setError(result?.error || '이메일 또는 비밀번호가 올바르지 않습니다.');
       }
-    } catch (err) {
-      setError('로그인 중 오류가 발생했습니다.');
+    } catch {
+      setError('로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
       setIsLoading(false);
     }
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-foreground">
-            로그인
-          </h2>
-          <p className="mt-2 text-center text-sm text-muted-foreground">
-            계정이 없으신가요?{' '}
-            <a href="/register" className="font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300">
-              회원가입
-            </a>
-          </p>
+    <div className="min-h-screen flex">
+      {/* ── 좌측: 브랜드 패널 (md 이상에서 표시) */}
+      <div className="hidden md:flex md:w-1/2 bg-gradient-to-br from-primary via-brand to-indigo-800 relative overflow-hidden flex-col items-center justify-center p-12 text-white">
+        {/* 배경 장식 */}
+        <div className="absolute inset-0 opacity-10">
+          <div className="absolute top-1/4 left-1/4 w-64 h-64 rounded-full bg-white blur-3xl" />
+          <div className="absolute bottom-1/4 right-1/4 w-48 h-48 rounded-full bg-white blur-3xl" />
         </div>
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {error && (
-            <div className="bg-destructive/10 border border-destructive/20 text-destructive px-4 py-3 rounded">
-              {error}
+
+        <div className="relative z-10 text-center max-w-sm">
+          {/* 로고 */}
+          <div className="flex items-center justify-center gap-3 mb-8">
+            <div className="w-12 h-12 rounded-xl bg-white/20 flex items-center justify-center">
+              <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
             </div>
-          )}
-          <div className="rounded-md shadow-sm -space-y-px">
+            <span className="text-2xl font-bold">Side Project Mate</span>
+          </div>
+
+          <h1 className="text-3xl font-bold mb-4 leading-snug">
+            함께 만드는<br />즐거운 사이드 프로젝트
+          </h1>
+          <p className="text-white/70 text-base leading-relaxed">
+            디자이너, 기획자, 개발자가 모여<br />아이디어를 현실로 만들어가는 공간
+          </p>
+
+          {/* 특징 아이콘 */}
+          <div className="mt-10 grid grid-cols-3 gap-4">
+            {[
+              { icon: '🤝', label: '팀 매칭' },
+              { icon: '📋', label: '칸반 보드' },
+              { icon: '📊', label: 'WBS 관리' },
+            ].map((feat) => (
+              <div key={feat.label} className="flex flex-col items-center gap-1">
+                <span className="text-2xl">{feat.icon}</span>
+                <span className="text-xs text-white/70">{feat.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── 우측: 로그인 폼 */}
+      <div className="w-full md:w-1/2 flex items-center justify-center px-6 py-12 bg-background">
+        <div className="w-full max-w-sm">
+          {/* 모바일용 로고 */}
+          <div className="md:hidden flex items-center gap-2 mb-8">
+            <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+              <svg className="w-5 h-5 text-primary-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+            </div>
+            <span className="font-bold text-foreground">Side Project Mate</span>
+          </div>
+
+          <h2 className="text-2xl font-bold text-foreground mb-1">로그인</h2>
+          <p className="text-sm text-muted-foreground mb-8">
+            계정이 없으신가요?{' '}
+            <Link href="/register" className="text-primary font-medium hover:underline">
+              회원가입
+            </Link>
+          </p>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* 에러 메시지 */}
+            {error && (
+              <div className="flex items-start gap-2 bg-destructive/10 border border-destructive/20 text-destructive px-4 py-3 rounded-lg text-sm">
+                <svg className="w-4 h-4 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                <span>{error}</span>
+              </div>
+            )}
+
+            {/* 이메일 */}
             <div>
-              <label htmlFor="authorEmail" className="sr-only">
-                이메일
-              </label>
+              <label htmlFor="authorEmail" className="form-label">이메일</label>
               <input
                 id="authorEmail"
                 name="authorEmail"
                 type="email"
                 autoComplete="email"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-input placeholder-muted-foreground text-foreground bg-background rounded-t-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                placeholder="이메일"
+                className="form-input"
+                placeholder="name@example.com"
                 value={formData.authorEmail}
                 onChange={handleChange}
               />
             </div>
-            <div>
-              <label htmlFor="password" className="sr-only">
-                비밀번호
-              </label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-input placeholder-muted-foreground text-foreground bg-background rounded-b-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                placeholder="비밀번호"
-                value={formData.password}
-                onChange={handleChange}
-              />
-            </div>
-          </div>
 
-          <div>
+            {/* 비밀번호 */}
+            <div>
+              <label htmlFor="password" className="form-label">비밀번호</label>
+              <div className="relative">
+                <input
+                  id="password"
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="current-password"
+                  required
+                  className="form-input pr-10"
+                  placeholder="비밀번호를 입력하세요"
+                  value={formData.password}
+                  onChange={handleChange}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(prev => !prev)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 표시'}
+                >
+                  {showPassword ? (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {/* 로그인 버튼 */}
             <button
               type="submit"
               disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+              className="btn-primary w-full py-2.5 mt-2"
             >
-              {isLoading ? '로그인 중...' : '로그인'}
+              {isLoading ? (
+                <>
+                  <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  로그인 중...
+                </>
+              ) : '로그인'}
             </button>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 export default function RegisterPage() {
   const [formData, setFormData] = useState({
@@ -14,142 +15,97 @@ export default function RegisterPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isNicknameLoading, setIsNicknameLoading] = useState(false);
+
+  // 유효성 상태
   const [emailError, setEmailError] = useState('');
   const [isEmailValid, setIsEmailValid] = useState(false);
-
-  // 컴포넌트 마운트 시 랜덤 닉네임 생성
-  useEffect(() => {
-    const initializeRandomNickname = async () => {
-      try {
-        const randomNick = await generateRandomNickname();
-        setFormData(prev => ({ ...prev, nName: randomNick }));
-      } catch (error) {
-        console.error('초기 닉네임 생성 실패:', error);
-      }
-    };
-
-    initializeRandomNickname();
-  }, []);
   const [passwordError, setPasswordError] = useState('');
   const [isPasswordValid, setIsPasswordValid] = useState(false);
   const [passwordStrength, setPasswordStrength] = useState<'위험' | '보통' | '안전' | ''>('');
   const [phoneError, setPhoneError] = useState('');
   const [isPhoneValid, setIsPhoneValid] = useState(false);
+
   const router = useRouter();
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value,
-    });
-  };
-
-  // 이메일 유효성 검사: 간단한 정규식 사용
-  useEffect(() => {
-    const email = formData.authorEmail.trim();
-    if (!email) {
-      setEmailError('');
-      setIsEmailValid(false);
-      return;
-    }
-
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (emailRegex.test(email)) {
-      setEmailError('');
-      setIsEmailValid(true);
-    } else {
-      setEmailError('유효한 이메일 형식이 아닙니다. 예: user@example.com');
-      setIsEmailValid(false);
-    }
-  }, [formData.authorEmail]);
-
-  // 비밀번호 복잡성 검사: 최소 길이 및 문자 종류(소문자, 대문자, 숫자, 특수문자) 중 최소 3개 포함
-  useEffect(() => {
-    const pw = formData.password || '';
-    const minLength = 8; // 가정: 최소 8자
-
-    if (!pw) {
-      setPasswordError('');
-      setIsPasswordValid(false);
-      return;
-    }
-
-    const checks = [/[a-z]/.test(pw), /[A-Z]/.test(pw), /\d/.test(pw), /[^A-Za-z0-9]/.test(pw)];
-    const passed = checks.filter(Boolean).length;
-
-    if (pw.length < minLength) {
-      setPasswordError(`비밀번호는 최소 ${minLength}자 이상이어야 합니다.`);
-      setIsPasswordValid(false);
-      return;
-    }
-
-    if (passed < 3) {
-      setPasswordError('비밀번호는 소문자, 대문자, 숫자, 특수문자 중 최소 3가지를 포함해야 합니다.');
-      setIsPasswordValid(false);
-      return;
-    }
-
-    setPasswordError('');
-    setIsPasswordValid(true);
-    // 비밀번호 강도 계산 (기존에 계산한 `passed` 재사용)
-    if (!pw) {
-      setPasswordStrength('');
-    } else if (passed <= 2 || pw.length < minLength) {
-      setPasswordStrength('위험');
-    } else if (passed === 3) {
-      setPasswordStrength('보통');
-    } else {
-      setPasswordStrength('안전');
-    }
-  }, [formData.password]);
-
-  // 휴대폰 번호 검증 (선택사항): 비어있으면 유효, 입력 시 숫자 길이 기준으로 간단 검사
-  useEffect(() => {
-    const raw = formData.mblNo || '';
-    // 한국 휴대폰 번호 검증 (국제전화번호, 핸드폰번호, (지역번호포함)일반전화번호)
-    const phoneRegex = /^(?:\+?82-?|0)(?:10|(?:2|3[1-3]|4[1-4]|5[1-5]|6[1-4]))-?\d{3,4}-?\d{4}$/;
-
-    if (!raw) {
-      setPhoneError('');
-      setIsPhoneValid(false);
-      return;
-    }
-
-    if (phoneRegex.test(raw)) {
-      setPhoneError('');
-      setIsPhoneValid(true);
-    } else {
-      setPhoneError('휴대폰 번호는 국제전화번호, 핸드폰번호, (지역번호포함)일반전화번호를 입력해주세요.');
-      setIsPhoneValid(false);
-    }
-  }, [formData.mblNo]);
-
-  // 랜덤 닉네임 생성기 (외부 API 사용)
+  // 랜덤 닉네임 생성
   const generateRandomNickname = async () => {
     try {
       const response = await fetch('https://www.rivestsoft.com/nickname/getRandomNickname.ajax', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ lang: 'ko' }),
       });
-
-      if (!response.ok) {
-        throw new Error('네트워크 응답이 정상이 아닙니다');
-      }
-
+      if (!response.ok) throw new Error('API error');
       const data = await response.json();
-      return data.data;
-    } catch (error) {
-      console.error('랜덤 닉네임 생성 실패:', error);
-      // API 호출 실패시 폴백으로 기본 랜덤 닉네임 생성
-      const prefix = 'user';
+      return data.data as string;
+    } catch {
       const rand = Math.random().toString(36).substring(2, 8);
-      const ts = Date.now().toString().slice(-4);
-      return `${prefix}_${rand}${ts}`.substring(0, 32);
+      return `user_${rand}`.substring(0, 32);
     }
   };
+
+  // 마운트 시 닉네임 자동 생성
+  useEffect(() => {
+    generateRandomNickname().then((nick) =>
+      setFormData((prev) => ({ ...prev, nName: nick }))
+    );
+  }, []);
+
+  // 닉네임 재생성 버튼
+  const handleRefreshNickname = async () => {
+    setIsNicknameLoading(true);
+    const nick = await generateRandomNickname();
+    setFormData((prev) => ({ ...prev, nName: nick }));
+    setIsNicknameLoading(false);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  // 이메일 유효성
+  useEffect(() => {
+    const email = formData.authorEmail.trim();
+    if (!email) { setEmailError(''); setIsEmailValid(false); return; }
+    const ok = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    setEmailError(ok ? '' : '유효한 이메일 형식이 아닙니다. 예: user@example.com');
+    setIsEmailValid(ok);
+  }, [formData.authorEmail]);
+
+  // 비밀번호 유효성
+  useEffect(() => {
+    const pw = formData.password;
+    if (!pw) { setPasswordError(''); setIsPasswordValid(false); setPasswordStrength(''); return; }
+    const checks = [/[a-z]/.test(pw), /[A-Z]/.test(pw), /\d/.test(pw), /[^A-Za-z0-9]/.test(pw)];
+    const passed = checks.filter(Boolean).length;
+    if (pw.length < 8) {
+      setPasswordError('비밀번호는 최소 8자 이상이어야 합니다.');
+      setIsPasswordValid(false);
+      setPasswordStrength('위험');
+      return;
+    }
+    if (passed < 3) {
+      setPasswordError('소문자, 대문자, 숫자, 특수문자 중 최소 3가지를 포함해야 합니다.');
+      setIsPasswordValid(false);
+      setPasswordStrength(passed <= 1 ? '위험' : '보통');
+      return;
+    }
+    setPasswordError('');
+    setIsPasswordValid(true);
+    setPasswordStrength(passed === 4 ? '안전' : '보통');
+  }, [formData.password]);
+
+  // 전화번호 유효성
+  useEffect(() => {
+    const raw = formData.mblNo;
+    if (!raw) { setPhoneError(''); setIsPhoneValid(false); return; }
+    const ok = /^(?:\+?82-?|0)(?:10|(?:2|3[1-3]|4[1-4]|5[1-5]|6[1-4]))-?\d{3,4}-?\d{4}$/.test(raw);
+    setPhoneError(ok ? '' : '올바른 전화번호 형식을 입력해주세요. 예: 010-1234-5678');
+    setIsPhoneValid(ok);
+  }, [formData.mblNo]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -162,39 +118,15 @@ export default function RegisterPage() {
       setIsLoading(false);
       return;
     }
-
-    // 비밀번호 유효성 재검증 (안전장치)
-    if (!isPasswordValid) {
-      setError('유효한 비밀번호를 입력하세요. 요구사항을 확인하세요.');
-      setIsLoading(false);
-      return;
-    }
-
-    // 이메일 유효성 재검증 (안전장치)
-    if (!isEmailValid) {
-      setError('유효한 이메일을 입력하세요.');
-      setIsLoading(false);
-      return;
-    }
-
-    // 휴대폰이 입력되어있다면 유효성 체크
-    if (formData.mblNo && !isPhoneValid) {
-      setError('휴대폰 번호 형식이 올바르지 않습니다.');
-      setIsLoading(false);
-      return;
-    }
+    if (!isPasswordValid) { setError('유효한 비밀번호를 입력하세요.'); setIsLoading(false); return; }
+    if (!isEmailValid) { setError('유효한 이메일을 입력하세요.'); setIsLoading(false); return; }
+    if (formData.mblNo && !isPhoneValid) { setError('휴대폰 번호 형식이 올바르지 않습니다.'); setIsLoading(false); return; }
 
     try {
-      // 닉네임이 비어있다면 랜덤 생성하여 전송
-      const nNameToSend = formData.nName && formData.nName.trim()
-        ? formData.nName.trim()
-        : await generateRandomNickname();
-
+      const nNameToSend = formData.nName?.trim() || await generateRandomNickname();
       const response = await fetch('/api/auth/register', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           authorEmail: formData.authorEmail,
           password: formData.password,
@@ -202,191 +134,283 @@ export default function RegisterPage() {
           mblNo: formData.mblNo,
         }),
       });
-
       const data = await response.json();
-
       if (data.success) {
-        // 닉네임이 자동 생성되었을 경우 폼에도 반영해 사용자에게 보여줌
-        if (!formData.nName || !formData.nName.trim()) {
-          setFormData((prev) => ({ ...prev, nName: nNameToSend }));
-        }
-        setSuccess('회원가입이 성공적으로 완료되었습니다. 로그인 페이지로 이동합니다...');
-        setTimeout(() => {
-          router.push('/login');
-        }, 2000);
+        setSuccess('회원가입이 완료되었습니다. 로그인 페이지로 이동합니다...');
+        setTimeout(() => router.push('/login'), 2000);
       } else {
-        setError(data.error);
+        setError(data.error || '회원가입에 실패했습니다.');
       }
-    } catch (err) {
+    } catch {
       setError('회원가입 중 오류가 발생했습니다.');
     } finally {
       setIsLoading(false);
     }
   };
 
+  // 비밀번호 강도 색상
+  const strengthColor = {
+    '': 'bg-muted',
+    위험: 'bg-destructive',
+    보통: 'bg-yellow-400',
+    안전: 'bg-green-500',
+  };
+  const strengthTextColor = {
+    '': '',
+    위험: 'text-destructive',
+    보통: 'text-yellow-600 dark:text-yellow-400',
+    안전: 'text-green-600 dark:text-green-400',
+  };
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-foreground">
-            회원가입
-          </h2>
-          <p className="mt-2 text-center text-sm text-muted-foreground">
-            이미 계정이 있으신가요?{' '}
-            <a href="/login" className="font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300">
-              로그인
-            </a>
+    <div className="min-h-screen flex">
+      {/* ── 좌측: 브랜드 패널 */}
+      <div className="hidden md:flex md:w-1/2 bg-gradient-to-br from-primary via-brand to-indigo-800 relative overflow-hidden flex-col items-center justify-center p-12 text-white">
+        <div className="absolute inset-0 opacity-10">
+          <div className="absolute top-1/3 left-1/3 w-64 h-64 rounded-full bg-white blur-3xl" />
+          <div className="absolute bottom-1/3 right-1/3 w-48 h-48 rounded-full bg-white blur-3xl" />
+        </div>
+        <div className="relative z-10 text-center max-w-sm">
+          <div className="flex items-center justify-center gap-3 mb-8">
+            <div className="w-12 h-12 rounded-xl bg-white/20 flex items-center justify-center">
+              <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+            </div>
+            <span className="text-2xl font-bold">Side Project Mate</span>
+          </div>
+          <h1 className="text-3xl font-bold mb-4 leading-snug">
+            당신의 아이디어를<br />팀과 함께 실현하세요
+          </h1>
+          <p className="text-white/70 text-base leading-relaxed">
+            지금 가입하고 다양한 사이드 프로젝트의<br />팀원을 만나보세요
           </p>
         </div>
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {error && (
-            <div className="bg-destructive/10 border border-destructive/20 text-destructive px-4 py-3 rounded">
-              {error}
+      </div>
+
+      {/* ── 우측: 회원가입 폼 */}
+      <div className="w-full md:w-1/2 flex items-center justify-center px-6 py-12 bg-background overflow-y-auto">
+        <div className="w-full max-w-sm">
+          {/* 모바일 로고 */}
+          <div className="md:hidden flex items-center gap-2 mb-8">
+            <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+              <svg className="w-5 h-5 text-primary-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
             </div>
-          )}
-          {success && (
-            <div className="bg-green-50 dark:bg-green-900/50 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-200 px-4 py-3 rounded">
-              {success}
-            </div>
-          )}
-          <div className="rounded-md shadow-sm -space-y-px">
+            <span className="font-bold text-foreground">Side Project Mate</span>
+          </div>
+
+          <h2 className="text-2xl font-bold text-foreground mb-1">회원가입</h2>
+          <p className="text-sm text-muted-foreground mb-8">
+            이미 계정이 있으신가요?{' '}
+            <Link href="/login" className="text-primary font-medium hover:underline">
+              로그인
+            </Link>
+          </p>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* 에러/성공 메시지 */}
+            {error && (
+              <div className="flex items-start gap-2 bg-destructive/10 border border-destructive/20 text-destructive px-4 py-3 rounded-lg text-sm">
+                <svg className="w-4 h-4 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                <span>{error}</span>
+              </div>
+            )}
+            {success && (
+              <div className="flex items-start gap-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-300 px-4 py-3 rounded-lg text-sm">
+                <svg className="w-4 h-4 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                <span>{success}</span>
+              </div>
+            )}
+
+            {/* 1. 이메일 */}
             <div>
-              <label htmlFor="authorEmail" className="sr-only">
-                이메일
-              </label>
+              <label htmlFor="authorEmail" className="form-label">이메일 <span className="text-destructive">*</span></label>
               <input
                 id="authorEmail"
                 name="authorEmail"
                 type="email"
                 autoComplete="email"
                 required
-                aria-invalid={!isEmailValid && !!formData.authorEmail}
-                className={`appearance-none rounded-none relative block w-full px-3 py-2 border placeholder-muted-foreground text-foreground bg-background rounded-t-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm ${!isEmailValid && formData.authorEmail ? 'border-red-500 focus:border-red-500' : 'border-input'
-                  }`}
-                placeholder="이메일"
+                className={`form-input ${!isEmailValid && formData.authorEmail ? 'border-destructive focus:ring-destructive' : ''}`}
+                placeholder="name@example.com"
                 value={formData.authorEmail}
                 onChange={handleChange}
               />
-              {emailError && (
-                <p className="mt-1 text-sm text-destructive" role="alert">
-                  {emailError}
-                </p>
+              {emailError && <p className="mt-1 text-xs text-destructive">{emailError}</p>}
+            </div>
+
+            {/* 2. 비밀번호 */}
+            <div>
+              <label htmlFor="password" className="form-label">비밀번호 <span className="text-destructive">*</span></label>
+              <div className="relative">
+                <input
+                  id="password"
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  required
+                  className={`form-input pr-10 ${!isPasswordValid && formData.password ? 'border-destructive focus:ring-destructive' : ''}`}
+                  placeholder="최소 8자, 3종 이상 조합"
+                  value={formData.password}
+                  onChange={handleChange}
+                />
+                <button type="button" onClick={() => setShowPassword(p => !p)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 표시'}>
+                  {showPassword ? (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+              {/* 비밀번호 강도 바 */}
+              {formData.password && (
+                <div className="mt-2">
+                  <div className="flex gap-1 mb-1">
+                    {(['위험', '보통', '안전'] as const).map((level, i) => (
+                      <div key={level} className={`h-1 flex-1 rounded-full transition-colors ${passwordStrength === '위험' && i === 0 ? strengthColor['위험'] :
+                          passwordStrength === '보통' && i <= 1 ? strengthColor['보통'] :
+                            passwordStrength === '안전' ? strengthColor['안전'] :
+                              'bg-muted'
+                        }`} />
+                    ))}
+                  </div>
+                  <div className="flex justify-between items-center">
+                    {passwordError
+                      ? <p className="text-xs text-destructive">{passwordError}</p>
+                      : <span />
+                    }
+                    {passwordStrength && (
+                      <span className={`text-xs font-semibold ml-auto ${strengthTextColor[passwordStrength]}`}>
+                        {passwordStrength}
+                      </span>
+                    )}
+                  </div>
+                </div>
               )}
             </div>
+
+            {/* 3. 비밀번호 확인 */}
             <div>
-              <label htmlFor="nName" className="sr-only">
-                닉네임
-              </label>
-              <input
-                id="nName"
-                name="nName"
-                type="text"
-                autoComplete="name"
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-input placeholder-muted-foreground text-foreground bg-background focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                placeholder="닉네임 (선택)"
-                maxLength={32}
-                value={formData.nName}
-                onChange={handleChange}
-              />
-              <div className="mt-1 flex items-center justify-between text-sm text-muted-foreground">
-                <span>{formData.nName.length}/32</span>
-                {!formData.nName && (
-                  <span className="italic">입력하지 않으면 랜덤 닉네임이 생성됩니다.</span>
-                )}
+              <label htmlFor="confirmPassword" className="form-label">비밀번호 확인 <span className="text-destructive">*</span></label>
+              <div className="relative">
+                <input
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  required
+                  className={`form-input pr-10 ${formData.confirmPassword && formData.password !== formData.confirmPassword
+                      ? 'border-destructive focus:ring-destructive' : ''
+                    }`}
+                  placeholder="비밀번호를 다시 입력하세요"
+                  value={formData.confirmPassword}
+                  onChange={handleChange}
+                />
+                <button type="button" onClick={() => setShowConfirmPassword(p => !p)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label={showConfirmPassword ? '비밀번호 숨기기' : '비밀번호 표시'}>
+                  {showConfirmPassword ? (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
               </div>
+              {formData.confirmPassword && formData.password !== formData.confirmPassword && (
+                <p className="mt-1 text-xs text-destructive">비밀번호가 일치하지 않습니다.</p>
+              )}
             </div>
+
+            {/* 4. 닉네임 */}
             <div>
-              <label htmlFor="mblNo" className="sr-only">
-                휴대폰 번호
+              <label htmlFor="nName" className="form-label">
+                닉네임 <span className="text-muted-foreground font-normal">(선택)</span>
+              </label>
+              <div className="flex gap-2">
+                <input
+                  id="nName"
+                  name="nName"
+                  type="text"
+                  autoComplete="nickname"
+                  className="form-input"
+                  placeholder="닉네임을 입력하세요"
+                  maxLength={32}
+                  value={formData.nName}
+                  onChange={handleChange}
+                />
+                <button
+                  type="button"
+                  onClick={handleRefreshNickname}
+                  disabled={isNicknameLoading}
+                  className="btn-secondary px-3 shrink-0"
+                  aria-label="닉네임 재생성"
+                  title="랜덤 닉네임 재생성"
+                >
+                  <svg className={`w-4 h-4 ${isNicknameLoading ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  </svg>
+                </button>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground text-right">
+                {formData.nName.length}/32
+              </p>
+            </div>
+
+            {/* 5. 전화번호 (선택) */}
+            <div>
+              <label htmlFor="mblNo" className="form-label">
+                휴대폰 번호 <span className="text-muted-foreground font-normal">(선택)</span>
               </label>
               <input
                 id="mblNo"
                 name="mblNo"
                 type="tel"
                 autoComplete="tel"
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-input placeholder-muted-foreground text-foreground bg-background focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                placeholder="휴대폰 번호 (선택)"
+                className={`form-input ${phoneError ? 'border-destructive focus:ring-destructive' : ''}`}
+                placeholder="010-1234-5678"
                 value={formData.mblNo}
                 onChange={handleChange}
               />
-              {phoneError && (
-                <p className="mt-1 text-sm text-destructive" role="alert">
-                  {phoneError}
-                </p>
-              )}
+              {phoneError && <p className="mt-1 text-xs text-destructive">{phoneError}</p>}
             </div>
-            <div>
-              <label htmlFor="password" className="sr-only">
-                비밀번호
-              </label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="new-password"
-                required
-                aria-invalid={!isPasswordValid && !!formData.password}
-                className={`appearance-none rounded-none relative block w-full px-3 py-2 border placeholder-muted-foreground text-foreground bg-background focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm ${!isPasswordValid && formData.password ? 'border-red-500 focus:border-red-500' : 'border-input'
-                  }`}
-                placeholder="비밀번호 (최소 8자, 4종 중 3종 포함 권장)"
-                value={formData.password}
-                onChange={handleChange}
-              />
-              {passwordError && (
-                <p className="mt-1 text-sm text-destructive" role="alert">
-                  {passwordError}
-                </p>
-              )}
-              {/* 비밀번호 강도 표시 */}
-              {passwordStrength && (
-                <div className="mt-2">
-                  <div className="flex items-center space-x-2">
-                    <span className="text-sm font-medium text-foreground">비밀번호 강도:</span>
-                    <span
-                      className={`text-sm font-semibold ${passwordStrength === '위험' ? 'text-red-600 dark:text-red-400' : passwordStrength === '보통' ? 'text-yellow-600 dark:text-yellow-400' : 'text-green-600 dark:text-green-400'
-                        }`}
-                    >
-                      {passwordStrength}
-                    </span>
-                  </div>
-                  <div className="mt-1 flex space-x-1">
-                    <span className={`h-1 flex-1 rounded ${passwordStrength === '위험' ? 'bg-red-600' : passwordStrength === '보통' ? 'bg-yellow-400' : 'bg-green-500'} ${passwordStrength === '보통' ? 'opacity-80' : ''}`} />
-                    <span className={`h-1 flex-1 rounded ${passwordStrength === '보통' ? (passwordStrength === '보통' ? 'bg-yellow-400' : 'bg-input') : passwordStrength === '안전' ? 'bg-green-500' : 'bg-input'}`} />
-                    <span className={`h-1 flex-1 rounded ${passwordStrength === '안전' ? 'bg-green-500' : 'bg-input'}`} />
-                  </div>
-                </div>
-              )}
-            </div>
-            <div>
-              <label htmlFor="confirmPassword" className="sr-only">
-                비밀번호 확인
-              </label>
-              <input
-                id="confirmPassword"
-                name="confirmPassword"
-                type="password"
-                autoComplete="new-password"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-input placeholder-muted-foreground text-foreground bg-background rounded-b-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                placeholder="비밀번호 확인"
-                value={formData.confirmPassword}
-                onChange={handleChange}
-              />
-            </div>
-          </div>
 
-          <div>
+            {/* 가입 버튼 */}
             <button
               type="submit"
               disabled={isLoading || !isEmailValid || !isPasswordValid}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+              className="btn-primary w-full py-2.5 mt-2"
             >
-              {isLoading ? '회원가입 중...' : '회원가입'}
+              {isLoading ? (
+                <>
+                  <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  가입 처리 중...
+                </>
+              ) : '회원가입'}
             </button>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </div>
   );
 }
-

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,79 +1,128 @@
 import Link from 'next/link';
 
 export default function Footer() {
-  const menuItems = [
-    { title: '메뉴1', href: '#' },
-    { title: '메뉴2', href: '#' },
-    { title: '메뉴3', href: '#' },
-    { title: '메뉴4', href: '#' },
-    { title: '메뉴5', href: '#' },
-    { title: '메뉴6', href: '#' },
-    { title: '메뉴7', href: '#' },
-    { title: '메뉴8', href: '#' },
-    { title: '메뉴9', href: '#' },
-    { title: '메뉴10', href: '#' },
+  const currentYear = new Date().getFullYear();
+
+  const serviceLinks = [
+    { label: '프로젝트 탐색', href: '/projects' },
+    { label: '내 프로필', href: '/profile' },
+    { label: '대시보드', href: '/dashboard' },
+    { label: '마이페이지', href: '/mypage' },
+  ];
+
+  const resourceLinks = [
+    { label: '이용약관', href: '#' },
+    { label: '개인정보처리방침', href: '#' },
+    { label: '공지사항', href: '#' },
+  ];
+
+  const socialLinks = [
+    {
+      label: 'GitHub',
+      href: 'https://github.com',
+      icon: (
+        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+          <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+        </svg>
+      ),
+    },
+    {
+      label: '이메일',
+      href: 'mailto:contact@sideprojectmate.com',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </svg>
+      ),
+    },
   ];
 
   return (
     <footer className="bg-accent border-t border-border mt-20">
       <div className="container mx-auto px-4 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          {/* 좌측: 전체 메뉴 */}
-          <div>
-            <h3 className="text-lg font-bold text-foreground mb-6">전체 메뉴</h3>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-              {menuItems.map((item, index) => (
-                <Link
-                  key={index}
-                  href={item.href}
-                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  {item.title}
-                </Link>
-              ))}
-            </div>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-10">
+
+          {/* ── 1열: 브랜드 소개 */}
+          <div className="md:col-span-1">
+            <Link href="/" className="flex items-center gap-2 mb-3">
+              <div className="w-7 h-7 rounded-md bg-primary flex items-center justify-center">
+                <svg className="w-4 h-4 text-primary-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+              </div>
+              <span className="font-bold text-foreground">Side Project Mate</span>
+            </Link>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              디자이너, 기획자, 개발자를 위한 사이드 프로젝트 팀 매칭 플랫폼
+            </p>
           </div>
 
-          {/* 우측: 회사 정보 */}
+          {/* ── 2열: 서비스 */}
           <div>
-            <h3 className="text-lg font-bold text-foreground mb-6">회사 정보</h3>
-            <div className="space-y-2 text-sm text-muted-foreground">
-              <p>
-                <span className="font-semibold">회사명:</span> (주)사이드프로젝트메이트
-              </p>
-              <p>
-                <span className="font-semibold">대표:</span> 홍길동
-              </p>
-              <p>
-                <span className="font-semibold">사업자등록번호:</span> 123-45-67890
-              </p>
-              <p>
-                <span className="font-semibold">주소:</span> 서울특별시 강남구 테헤란로 123
-              </p>
-              <p>
-                <span className="font-semibold">이메일:</span> contact@sideprojectmate.com
-              </p>
-              <p>
-                <span className="font-semibold">고객센터:</span> 1234-5678
-              </p>
+            <h4 className="text-sm font-semibold text-foreground mb-4">서비스</h4>
+            <ul className="space-y-2.5">
+              {serviceLinks.map((link) => (
+                <li key={link.label}>
+                  <Link
+                    href={link.href}
+                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* ── 3열: 리소스 */}
+          <div>
+            <h4 className="text-sm font-semibold text-foreground mb-4">리소스</h4>
+            <ul className="space-y-2.5">
+              {resourceLinks.map((link) => (
+                <li key={link.label}>
+                  <Link
+                    href={link.href}
+                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* ── 4열: 소셜 */}
+          <div>
+            <h4 className="text-sm font-semibold text-foreground mb-4">소셜</h4>
+            <div className="flex gap-3">
+              {socialLinks.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={link.label}
+                  className="p-2 text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors"
+                >
+                  {link.icon}
+                </a>
+              ))}
             </div>
           </div>
         </div>
 
-        {/* 하단 저작권 */}
-        <div className="mt-12 pt-8 border-t border-border">
-          <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-            <p className="text-sm text-muted-foreground">
-              © 2025 Side Project Mate. All rights reserved.
-            </p>
-            <div className="flex gap-6">
-              <Link href="#" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-                이용약관
-              </Link>
-              <Link href="#" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-                개인정보처리방침
-              </Link>
-            </div>
+        {/* ── 하단 저작권 */}
+        <div className="mt-10 pt-6 border-t border-border flex flex-col sm:flex-row justify-between items-center gap-3">
+          <p className="text-xs text-muted-foreground">
+            © {currentYear} Side Project Mate. All rights reserved.
+          </p>
+          <div className="flex gap-4">
+            <Link href="#" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+              이용약관
+            </Link>
+            <Link href="#" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+              개인정보처리방침
+            </Link>
           </div>
         </div>
       </div>

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link';
+import React from 'react';
+
+/* ============================================================
+   EmptyState — 데이터가 없을 때 표시하는 공통 UI
+   사용법:
+     <EmptyState
+       icon="search"
+       title="검색 결과가 없습니다"
+       description="다른 키워드로 검색해보세요."
+       action={{ label: '프로젝트 탐색', href: '/projects' }}
+     />
+============================================================ */
+
+type EmptyIcon =
+    | 'search'
+    | 'inbox'
+    | 'folder'
+    | 'users'
+    | 'document'
+    | 'bell'
+    | 'chart';
+
+interface EmptyStateAction {
+    label: string;
+    href?: string;
+    onClick?: () => void;
+}
+
+interface EmptyStateProps {
+    icon?: EmptyIcon;
+    title: string;
+    description?: string;
+    action?: EmptyStateAction;
+    className?: string;
+}
+
+const ICONS: Record<EmptyIcon, React.ReactNode> = {
+    search: (
+        <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+    ),
+    inbox: (
+        <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+        </svg>
+    ),
+    folder: (
+        <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
+        </svg>
+    ),
+    users: (
+        <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+    ),
+    document: (
+        <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+    ),
+    bell: (
+        <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+        </svg>
+    ),
+    chart: (
+        <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+        </svg>
+    ),
+};
+
+export default function EmptyState({
+    icon = 'inbox',
+    title,
+    description,
+    action,
+    className = '',
+}: EmptyStateProps) {
+    return (
+        <div className={`flex flex-col items-center justify-center py-16 px-4 text-center ${className}`}>
+            {/* 아이콘 */}
+            <div className="text-muted-foreground/40 mb-4">
+                {ICONS[icon]}
+            </div>
+
+            {/* 텍스트 */}
+            <h3 className="text-lg font-semibold text-foreground mb-1">{title}</h3>
+            {description && (
+                <p className="text-sm text-muted-foreground max-w-xs">{description}</p>
+            )}
+
+            {/* 액션 버튼 */}
+            {action && (
+                <div className="mt-6">
+                    {action.href ? (
+                        <Link href={action.href} className="btn-primary">
+                            {action.label}
+                        </Link>
+                    ) : (
+                        <button onClick={action.onClick} className="btn-primary">
+                            {action.label}
+                        </button>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+
+/* ============================================================
+   Skeleton — 로딩 상태용 애니메이션 플레이스홀더
+   사용법:
+     <Skeleton className="h-5 w-32" />
+     <Skeleton.Avatar size="md" />
+     <Skeleton.Card />
+============================================================ */
+
+interface SkeletonProps {
+    className?: string;
+    rounded?: 'none' | 'sm' | 'md' | 'lg' | 'full';
+}
+
+/** 기본 Skeleton 블록 */
+function Skeleton({ className = '', rounded = 'md' }: SkeletonProps) {
+    const roundedClass = {
+        none: '',
+        sm: 'rounded-sm',
+        md: 'rounded-md',
+        lg: 'rounded-lg',
+        full: 'rounded-full',
+    }[rounded];
+
+    return (
+        <div
+            className={`animate-pulse bg-muted ${roundedClass} ${className}`}
+            aria-hidden="true"
+        />
+    );
+}
+
+/** 아바타 Skeleton */
+Skeleton.Avatar = function SkeletonAvatar({
+    size = 'md',
+}: {
+    size?: 'sm' | 'md' | 'lg' | 'xl';
+}) {
+    const sizeClass = {
+        sm: 'w-8 h-8',
+        md: 'w-10 h-10',
+        lg: 'w-14 h-14',
+        xl: 'w-20 h-20',
+    }[size];
+
+    return <Skeleton className={sizeClass} rounded="full" />;
+};
+
+/** 텍스트 줄 Skeleton */
+Skeleton.Text = function SkeletonText({
+    lines = 1,
+    lastLineFull = false,
+}: {
+    lines?: number;
+    lastLineFull?: boolean;
+}) {
+    return (
+        <div className="space-y-2">
+            {Array.from({ length: lines }).map((_, i) => (
+                <Skeleton
+                    key={i}
+                    className={`h-4 ${i === lines - 1 && !lastLineFull ? 'w-3/4' : 'w-full'}`}
+                />
+            ))}
+        </div>
+    );
+};
+
+/** 카드 Skeleton */
+Skeleton.Card = function SkeletonCard() {
+    return (
+        <div className="bg-card border border-border rounded-xl p-4 space-y-3" aria-hidden="true">
+            {/* 썸네일 */}
+            <Skeleton className="h-40 w-full" rounded="lg" />
+            {/* 텍스트 줄 */}
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            {/* 하단 메타 */}
+            <div className="flex items-center gap-2 pt-1">
+                <Skeleton.Avatar size="sm" />
+                <Skeleton className="h-4 w-24" />
+            </div>
+        </div>
+    );
+};
+
+/** 프로필 Skeleton */
+Skeleton.Profile = function SkeletonProfile() {
+    return (
+        <div className="flex items-center gap-4 p-4" aria-hidden="true">
+            <Skeleton.Avatar size="xl" />
+            <div className="flex-1 space-y-2">
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-4 w-56" />
+                <Skeleton className="h-4 w-32" />
+            </div>
+        </div>
+    );
+};
+
+/** 리스트 항목 Skeleton */
+Skeleton.ListItem = function SkeletonListItem() {
+    return (
+        <div className="flex items-center gap-3 py-3 px-4 border-b border-border last:border-0" aria-hidden="true">
+            <Skeleton.Avatar size="md" />
+            <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-4 w-1/3" />
+                <Skeleton className="h-3 w-2/3" />
+            </div>
+            <Skeleton className="h-6 w-16" rounded="full" />
+        </div>
+    );
+};
+
+export default Skeleton;

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { create } from 'zustand';
+
+/* ============================================================
+   Toast 상태 스토어 (Zustand)
+   사용법: toastStore.getState().show('저장되었습니다.', 'success')
+   또는 훅: const { show } = useToastStore();
+============================================================ */
+export type ToastType = 'default' | 'success' | 'error' | 'warning';
+
+interface ToastItem {
+    id: string;
+    message: string;
+    type: ToastType;
+}
+
+interface ToastStoreState {
+    toasts: ToastItem[];
+    show: (message: string, type?: ToastType, duration?: number) => void;
+    remove: (id: string) => void;
+}
+
+export const useToastStore = create<ToastStoreState>((set) => ({
+    toasts: [],
+    show: (message, type = 'default', duration = 3000) => {
+        const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        set((s) => ({ toasts: [...s.toasts, { id, message, type }] }));
+        setTimeout(() => {
+            set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+        }, duration);
+    },
+    remove: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}));
+
+/* ============================================================
+   Toast 아이콘
+============================================================ */
+function ToastIcon({ type }: { type: ToastType }) {
+    if (type === 'success') {
+        return (
+            <svg className="w-5 h-5 text-green-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+        );
+    }
+    if (type === 'error') {
+        return (
+            <svg className="w-5 h-5 text-red-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        );
+    }
+    if (type === 'warning') {
+        return (
+            <svg className="w-5 h-5 text-yellow-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+        );
+    }
+    // default: 알림 벨 아이콘
+    return (
+        <svg className="w-5 h-5 text-brand shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+        </svg>
+    );
+}
+
+/* ============================================================
+   개별 Toast 아이템 (마운트 애니메이션 포함)
+============================================================ */
+function ToastItem({ toast, onRemove }: { toast: ToastItem; onRemove: () => void }) {
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        const t = setTimeout(() => setVisible(true), 10);
+        return () => clearTimeout(t);
+    }, []);
+
+    return (
+        <div
+            className={`
+        flex items-center gap-3 px-4 py-3 rounded-xl shadow-lg border border-border
+        bg-card text-card-foreground text-sm font-medium
+        transition-all duration-300 ease-out
+        ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'}
+      `}
+        >
+            <ToastIcon type={toast.type} />
+            <span className="flex-1">{toast.message}</span>
+            <button
+                onClick={() => { setVisible(false); setTimeout(onRemove, 300); }}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="알림 닫기"
+            >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
+    );
+}
+
+/* ============================================================
+   Toast 컨테이너 — layout.tsx에서 한 번만 마운트
+============================================================ */
+export default function Toast() {
+    const { toasts, remove } = useToastStore();
+
+    if (toasts.length === 0) return null;
+
+    return (
+        <div
+            className="fixed bottom-4 right-4 z-[200] flex flex-col gap-2 w-[340px] max-w-[calc(100vw-2rem)]"
+            aria-live="polite"
+            aria-atomic="false"
+        >
+            {toasts.map((toast) => (
+                <ToastItem key={toast.id} toast={toast} onRemove={() => remove(toast.id)} />
+            ))}
+        </div>
+    );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,50 +9,49 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        border: "var(--border)",
-        input: "var(--input)",
-        ring: "var(--ring)",
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        /* 시스템 토큰 (CSS 변수 연결) */
+        border: 'var(--border)',
+        input: 'var(--input)',
+        ring: 'var(--ring)',
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+
+        /* 브랜드 컬러 */
+        brand: {
+          DEFAULT: 'var(--brand)',
+          hover: 'var(--brand-hover)',
+          light: 'var(--brand-light)',
+          foreground: 'var(--brand-foreground)',
+        },
+
         primary: {
-          50: '#f9fafb',
-          100: '#f3f4f6',
-          200: '#e5e7eb',
-          300: '#d1d5db',
-          400: '#9ca3af',
-          500: '#6b7280',
-          600: '#4b5563',
-          700: '#374151',
-          800: '#1f2937',
-          900: '#111827',
-          DEFAULT: "var(--primary)",
-          foreground: "var(--primary-foreground)",
+          DEFAULT: 'var(--primary)',
+          hover: 'var(--primary-hover)',
+          foreground: 'var(--primary-foreground)',
         },
         secondary: {
-          DEFAULT: "var(--secondary)",
-          foreground: "var(--secondary-foreground)",
+          DEFAULT: 'var(--secondary)',
+          foreground: 'var(--secondary-foreground)',
         },
         destructive: {
-          DEFAULT: "var(--destructive)",
-          foreground: "var(--destructive-foreground)",
+          DEFAULT: 'var(--destructive)',
+          foreground: 'var(--destructive-foreground)',
         },
         muted: {
-          DEFAULT: "var(--muted)",
-          foreground: "var(--muted-foreground)",
+          DEFAULT: 'var(--muted)',
+          foreground: 'var(--muted-foreground)',
         },
         accent: {
-          light: '#f8f9fa',
-          dark: '#dee2e6',
-          DEFAULT: "var(--accent)",
-          foreground: "var(--accent-foreground)",
+          DEFAULT: 'var(--accent)',
+          foreground: 'var(--accent-foreground)',
         },
         popover: {
-          DEFAULT: "var(--popover)",
-          foreground: "var(--popover-foreground)",
+          DEFAULT: 'var(--popover)',
+          foreground: 'var(--popover-foreground)',
         },
         card: {
-          DEFAULT: "var(--card)",
-          foreground: "var(--card-foreground)",
+          DEFAULT: 'var(--card)',
+          foreground: 'var(--card-foreground)',
         },
       },
       fontFamily: {
@@ -67,6 +66,10 @@ module.exports = {
           xl: '5rem',
           '2xl': '6rem',
         },
+      },
+      animation: {
+        'slide-in-up': 'slide-in-up 0.25s ease-out forwards',
+        'fade-in': 'fade-in 0.2s ease-out forwards',
       },
     },
   },


### PR DESCRIPTION
- globals.css: 브랜드 컬러(indigo) 도입, 공통 클래스 정비(btn-primary, form-input, badge)
- tailwind.config.js: brand 컬러 토큰 추가
- Header: SVG 로고, 아바타 드롭다운, 다크모드 토글 헤더 통합, 모바일 슬라이드 패널
- Footer: 4컬럼 레이아웃, 더미 데이터 제거, 소셜 링크 추가, 동적 저작권 연도
- login/page.tsx: 2분할 레이아웃, 시각적 라벨, 비밀번호 토글
- register/page.tsx: 2분할 레이아웃, 입력 순서 정렬, 닉네임 재생성 버튼
- common/Toast.tsx: Zustand 기반 Toast 스토어 + 컴포넌트 신설
- common/Skeleton.tsx: 재사용 Skeleton 컴포넌트(5종 프리셋)
- common/EmptyState.tsx: EmptyState 컴포넌트(8종 아이콘) 신설
- layout.tsx: FloatingThemeButton 제거, Toast 등록, OG 메타데이터 추가