### PR TITLE
feat: 채팅방 관리 시스템 구현 (Phase 9)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -255,6 +255,21 @@ app.prepare().then(() => {
             const chatRoomKey = `chat-${roomId}`;
             socket.to(chatRoomKey).emit('messages-read-receipt', { roomId, readByUserId: userId });
         });
+
+        // Step 9.5: 새 채팅방 생성 알림 브로드캐스트
+        // POST /api/chat/rooms에서 방 생성 후 클라이언트가 이 이벤트를 발생시키면
+        // 상대방의 개인 소켓 Room에 new-room 이벤트를 전송해서 목록을 실시간 갱신!
+        socket.on('notify-new-room', ({ participantIds, room }) => {
+            participantIds.forEach((participantId: string) => {
+                socket.to(`user-${participantId}`).emit('new-room', room);
+            });
+        });
+
+        // 개인 소켓 Room 입장 (로그인 후 user-{id} 방에 join해야 new-room 등 개인 이벤트를 받을 수 있어!)
+        socket.on('join-user-room', ({ userId }) => {
+            socket.join(`user-${userId}`);
+        });
+
         socket.on('disconnect', () => {
 
             // 1. [기존] 이 소켓이 잠근 모든 리소스 해제

--- a/src/app/api/chat/rooms/[roomId]/route.ts
+++ b/src/app/api/chat/rooms/[roomId]/route.ts
@@ -1,0 +1,79 @@
+
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import dbConnect from '@/lib/mongodb';
+import ChatRoom from '@/lib/models/ChatRoom';
+
+// Step 9.4: 채팅방 나가기
+// - 참여자 배열에서 현재 사용자 제거
+// - 참여자가 0명이 되면 채팅방 자체를 삭제
+export async function DELETE(
+    _request: Request,
+    { params }: { params: { roomId: string } }
+) {
+    try {
+        // 1. 인증 확인
+        const session = await getServerSession(authOptions);
+        if (!session || !session.user?._id) {
+            return NextResponse.json(
+                { success: false, message: '로그인이 필요한 서비스입니다.' },
+                { status: 401 }
+            );
+        }
+        const currentUserId = session.user._id;
+        const { roomId } = params;
+
+        // 2. DB 연결
+        await dbConnect();
+
+        // 3. 대상 채팅방 조회
+        const room = await ChatRoom.findById(roomId);
+        if (!room) {
+            return NextResponse.json(
+                { success: false, message: '채팅방을 찾을 수 없습니다.' },
+                { status: 404 }
+            );
+        }
+
+        // 4. 내가 이 방의 참여자인지 확인
+        const isParticipant = room.participants.some(
+            (p: any) => p.toString() === currentUserId
+        );
+        if (!isParticipant) {
+            return NextResponse.json(
+                { success: false, message: '해당 채팅방의 참여자가 아닙니다.' },
+                { status: 403 }
+            );
+        }
+
+        // 5. 참여자 배열에서 현재 사용자 제거
+        room.participants = room.participants.filter(
+            (p: any) => p.toString() !== currentUserId
+        );
+
+        if (room.participants.length === 0) {
+            // 6a. 참여자가 0명이 되면 방 자체 삭제
+            await ChatRoom.findByIdAndDelete(roomId);
+            return NextResponse.json({
+                success: true,
+                message: '채팅방이 삭제되었습니다.',
+                data: { deleted: true }
+            });
+        } else {
+            // 6b. 아직 참여자가 남아 있으면 방 유지 (나만 나감)
+            await room.save();
+            return NextResponse.json({
+                success: true,
+                message: '채팅방에서 나갔습니다.',
+                data: { deleted: false }
+            });
+        }
+
+    } catch (error: any) {
+        return NextResponse.json(
+            { success: false, message: '채팅방 나가기 중 오류가 발생했습니다.', error: error.message },
+            { status: 500 }
+        );
+    }
+}

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -2,7 +2,15 @@ import { useEffect, useState, useCallback } from 'react';
 import { getSocket } from '@/lib/socket';
 import { Socket } from 'socket.io-client';
 
-export const useChatSocket = (roomId?: string) => {
+// 🔧 Step 9.1: userId를 외부에서 prop으로 받아서 sessionStorage 의존성 완전 제거
+// 이전에는 useChatSocket 내부에서 sessionStorage를 직접 읽었으나,
+// 이제 ChatWindow에서 실제 세션 userId를 받아서 주입하는 방식으로 변경했어!
+interface UseChatSocketOptions {
+    roomId?: string;
+    userId?: string; // 실제 로그인 사용자 ID (ChatWindow에서 주입)
+}
+
+export const useChatSocket = ({ roomId, userId }: UseChatSocketOptions = {}) => {
     const [socket, setSocket] = useState<Socket | null>(null);
     const [isConnected, setIsConnected] = useState(false);
 
@@ -20,11 +28,8 @@ export const useChatSocket = (roomId?: string) => {
         socketInstance.on('disconnect', onDisconnect);
 
         // 3. 특정 방(roomId)이 주어지면 방에 입장 (Join Room)
-        if (roomId) {
-            // TODO: Step 8.4 완료 후 실제 세션 userId로 교체 예정
-            // 현재는 ChatWindow에서 useSession으로 실제 userId를 사용하고 있으므로
-            // 소켓 join 시에도 sessionStorage fallback 대신 빈 값으로만 전달
-            const userId = sessionStorage.getItem('spm_mock_userId') ?? '';
+        if (roomId && userId) {
+            // 🔧 Step 9.1: 이제 sessionStorage 없이 실제 userId 주입!
             socketInstance.emit('join-chat-room', { roomId, userId });
 
             // 📢 [Step 7.2] 방에 들어왔으니 "나 여기 있는 메시지 다 읽었음!" 신호 전송
@@ -33,8 +38,7 @@ export const useChatSocket = (roomId?: string) => {
 
         // 4. 클린업 (컴포넌트 언마운트 시)
         return () => {
-            if (roomId) {
-                const userId = sessionStorage.getItem('spm_mock_userId') ?? '';
+            if (roomId && userId) {
                 socketInstance.emit('leave-chat-room', { roomId, userId });
             }
 
@@ -45,7 +49,7 @@ export const useChatSocket = (roomId?: string) => {
             // 컴포넌트 언마운트 시 무조건 disconnectSocket()을 호출하면 안됨.
             // 필요하다면 전역 소켓 관리 로직을 더 정교하게 다듬어야 함.
         };
-    }, [roomId]);
+    }, [roomId, userId]);
 
     // 외부 컴포넌트에서 이벤트를 구독하거나 해제할 수 있는 헬퍼 함수
     const subscribe = useCallback((event: string, callback: (...args: any[]) => void) => {


### PR DESCRIPTION
feat: 채팅방 관리 시스템 구현 (Phase 9)

[프론트엔드 (Frontend)]
- useChatSocket.ts: userId를 외부 prop으로 주입받는 방식으로 변경, sessionStorage 의존 완전 제거
- ChatWindow.tsx: 새 소켓 훅 시그니처 적용 / 헤더 ⋮ 메뉴 드롭다운 추가 / 채팅방 나가기 GlobalModal 확인창 연동
- chat/page.tsx: MOCK_ROOMS 하드코딩 제거 → GET /api/chat/rooms 실제 API 연동
- chat/page.tsx: ?roomId 쿼리 파라미터로 특정 방 자동 활성화 (DM 보내기 진입점 대응)
- chat/page.tsx: 나가기 완료 시 목록에서 해당 방 즉시 제거
- chat/page.tsx: receive_message 소켓 이벤트로 목록 lastMessage/updatedAt 실시간 갱신
- chat/page.tsx: new-room 소켓 이벤트로 상대방이 시작한 DM 방이 목록에 즉시 표시

[백엔드 (Backend)]
- GET /api/chat/rooms: 내가 참여 중인 채팅방 목록 조회 API 신규 구현 (updatedAt 기준 최신 순, participants populate)
- DELETE /api/chat/rooms/[roomId]: 채팅방 나가기 API 신규 구현 (참여자 배열에서 제거, 0명 시 방 삭제)
- server.ts: notify-new-room 소켓 이벤트 추가 (신규 방 생성 시 상대 참여자에게 실시간 알림)
- server.ts: join-user-room 소켓 이벤트 추가 (user-{id} 개인 Room에 join하여 개인 이벤트 수신 가능)
