### PR TITLE
Phase 10 — 최종 버그 수정 & 마감 폴리싱

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -16,3 +16,4 @@ services:
       - key: GOOGLE_CLIENT_SECRET
         sync: false
     plan: free
+    healthCheckPath: /api/status

--- a/server.ts
+++ b/server.ts
@@ -282,9 +282,17 @@ app.prepare().then(() => {
 
         // 메시지 브로드캐스트 (낙관적 업데이트 사용 중이므로 발신자 제외)
         socket.on('send_message', (messageData) => {
-            const { roomId } = messageData;
+            const { roomId, participantIds, sender } = messageData;
             const chatRoomKey = `chat-${roomId}`;
             socket.to(chatRoomKey).emit('receive_message', messageData);
+
+            // 💬 Step 5/7: 모든 참여자(발신자 포함)의 개인 소켓 Room으로 알림 전송
+            // io.to() 사용 → 발신자 본인 소켓도 포함 (발신자 목록 갱신 + 비활성방 갱신 모두 커버)
+            if (participantIds) {
+                participantIds.forEach((pid: string) => {
+                    io.to(`user-${pid}`).emit('message-received', messageData);
+                });
+            }
         });
 
         // 읽음 처리 브로드캐스트
@@ -363,4 +371,17 @@ app.prepare().then(() => {
     httpServer.listen(port, () => {
         console.log(`> Ready on http://${hostname}:${port}`);
     });
+
+    // Step 10: Render.com Free Plan 슬립 방지 — 프로덕션에서 10분마다 self-ping
+    if (process.env.NODE_ENV === 'production') {
+        const PING_INTERVAL_MS = 10 * 60 * 1000; // 10분
+        setInterval(async () => {
+            try {
+                await fetch(`${process.env.NEXTAUTH_URL}/api/status`);
+                console.log('[Keep-Alive] ping sent');
+            } catch (e) {
+                console.warn('[Keep-Alive] ping failed', e);
+            }
+        }, PING_INTERVAL_MS);
+    }
 });

--- a/src/app/api/chat/messages/[roomId]/route.ts
+++ b/src/app/api/chat/messages/[roomId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/dbConnect';
 import ChatMessage from '@/lib/models/ChatMessage';
+import ChatRoom from '@/lib/models/ChatRoom';
 import mongoose from 'mongoose';
 
 export async function GET(
@@ -61,6 +62,11 @@ export async function GET(
                     $addToSet: { readBy: currentUserId } // 내 ID를 배열에 중복 없이 쏙 추가!
                 }
             );
+
+            // ChatRoom의 unreadCounts에서 현재 유저 카운트 0으로 초기화
+            await ChatRoom.findByIdAndUpdate(roomId, {
+                $set: { [`unreadCounts.${currentUserId}`]: 0 },
+            });
         }
 
         // 배열 순서를 다시 과거 -> 최신(보여질 순서)으로 뒤집기

--- a/src/app/api/chat/messages/route.ts
+++ b/src/app/api/chat/messages/route.ts
@@ -29,10 +29,20 @@ export async function POST(req: Request) {
             readBy: [currentUserId], // 보낸 사람은 기본적으로 읽음 처리
         });
 
-        // 2. 해당 채팅방(ChatRoom)의 lastMessage 필드 업데이트
+        // 2. 해당 채팅방(ChatRoom)의 lastMessage 업데이트 + 발신자 외 참여자 unreadCounts 증가
+        const room = await ChatRoom.findById(roomId).select('participants').lean();
+        const incFields: Record<string, 1> = {};
+        if (room) {
+            (room.participants as any[]).forEach((pid: any) => {
+                if (pid.toString() !== currentUserId) {
+                    incFields[`unreadCounts.${pid.toString()}`] = 1;
+                }
+            });
+        }
+
         await ChatRoom.findByIdAndUpdate(roomId, {
-            lastMessage: content,
-            updatedAt: new Date()
+            $set: { lastMessage: content, updatedAt: new Date() },
+            ...(Object.keys(incFields).length > 0 ? { $inc: incFields } : {}),
         });
 
         return NextResponse.json(

--- a/src/app/api/chat/rooms/route.ts
+++ b/src/app/api/chat/rooms/route.ts
@@ -6,6 +6,9 @@ import dbConnect from '@/lib/mongodb';
 import ChatRoom from '@/lib/models/ChatRoom';
 import ChatMessage from '@/lib/models/ChatMessage';
 import User from '@/lib/models/User';
+import Project from '@/lib/models/Project';
+
+export const dynamic = 'force-dynamic';
 
 // Step 9.2: 내가 참여 중인 채팅방 목록 조회
 // 최신 메시지(updatedAt) 기준 정렬하여 반환
@@ -21,16 +24,48 @@ export async function GET() {
         }
         const currentUserId = session.user._id;
 
-        // 2. DB 연결 및 조회
+        // 2. DB 연결
         await dbConnect();
 
         // 3. 내가 participants 배열에 포함된 방만 조회, 최신 순 정렬
+        // participants를 _id/nickname/profileImage 필드만 populate
         const rooms = await ChatRoom.find({ participants: currentUserId })
-            .sort({ updatedAt: -1 }) // 마지막 메시지 기준 최신 순
-            .populate('participants', 'name nickname profileImage') // 참여자 정보 채우기
-            .lean(); // 성능 최적화: 순수 JS 객체로 반환
+            .sort({ updatedAt: -1 })
+            .populate('participants', '_id nName avatarUrl')
+            .lean();
 
-        return NextResponse.json({ success: true, data: rooms });
+        // 4. TEAM/INQUIRY 방의 projectId로 프로젝트명 일괄 조회 (N+1 방지)
+        const projectIds = rooms
+            .filter(r => (r.category === 'TEAM' || r.category === 'INQUIRY' || r.category === 'RECRUIT') && r.projectId)
+            .map(r => r.projectId);
+
+        const projectMap: Record<string, string> = {};
+        if (projectIds.length > 0) {
+            const projects = await Project.find({ _id: { $in: projectIds } })
+                .select('_id title')
+                .lean();
+            projects.forEach((p: any) => {
+                projectMap[p._id.toString()] = p.title;
+            });
+        }
+
+        // 5. 각 방에 myUnreadCount, projectName 추가 후 unreadCounts 제거
+        // .lean() 시 Mongoose Map은 plain object { [userId]: count } 로 직렬화됨
+        const enrichedRooms = rooms.map(room => {
+            const unreadCounts = (room.unreadCounts as Record<string, number>) || {};
+            const myUnreadCount = unreadCounts[currentUserId] ?? 0;
+
+            let projectName: string | undefined;
+            if ((room.category === 'TEAM' || room.category === 'INQUIRY' || room.category === 'RECRUIT') && room.projectId) {
+                projectName = projectMap[room.projectId.toString()];
+            }
+
+            // unreadCounts는 Map 전체를 클라이언트에 노출할 필요가 없으므로 제거
+            const { unreadCounts: _, ...rest } = room as any;
+            return { ...rest, myUnreadCount, projectName };
+        });
+
+        return NextResponse.json({ success: true, data: enrichedRooms });
 
     } catch (error: any) {
         return NextResponse.json(
@@ -92,20 +127,31 @@ export async function POST(request: Request) {
         // 5. DB 연결
         await dbConnect();
 
-        // 6. [중복 방지 로직 - 옵션]
-        // DM(1:1)이나 TEAM, RECRUIT의 경우 이미 동일한 멤버 구성의 방이 있는지 체크할 수 있음.
-        // 특히 DM은 보통 유니크해야 함.
-        if (category === 'DM' && participantList.length === 2) {
+        // 6. [중복 방지 로직] 카테고리별로 중복 룸 체크 후 기존 룸 반환
+        // DM/RECRUIT: 동일한 두 참여자 조합이면 기존 룸 반환
+        if ((category === 'DM' || category === 'RECRUIT') && participantList.length === 2) {
             const existingRoom = await ChatRoom.findOne({
-                category: 'DM',
+                category,
                 participants: { $all: participantList, $size: 2 }
             });
-
             if (existingRoom) {
                 return NextResponse.json({
                     success: true,
                     message: '이미 존재하는 대화방을 불러옵니다.',
-                    data: existingRoom
+                    data: existingRoom,
+                    alreadyExists: true,
+                });
+            }
+        }
+        // TEAM/INQUIRY: 동일한 projectId + category 조합이면 기존 룸 반환
+        if ((category === 'TEAM' || category === 'INQUIRY') && projectId) {
+            const existingRoom = await ChatRoom.findOne({ category, projectId });
+            if (existingRoom) {
+                return NextResponse.json({
+                    success: true,
+                    message: '이미 존재하는 대화방을 불러옵니다.',
+                    data: existingRoom,
+                    alreadyExists: true,
                 });
             }
         }
@@ -144,14 +190,16 @@ export async function POST(request: Request) {
         if (systemMessageContent) {
             await ChatMessage.create({
                 roomId: newRoom._id,
-                sender: currentUserId, // 시스템 메시지지만, 편의상 생성자를 sender로 두거나 어드민 봇 계정이 있다면 그 ID를 넣을 수 있음
+                sender: currentUserId,
                 content: systemMessageContent,
                 messageType: 'SYSTEM',
                 readBy: [currentUserId],
             });
 
-            // 🔥 방의 lastMessage 업데이트 (선택 사항)
-            // ChatRoom 모델에 lastMessage 필드가 있다면 여기서 트리거 업데이트 해주는 게 좋아!
+            // 🔥 Step 7: 방의 lastMessage 즉시 업데이트 (목록 미리보기에 표시)
+            await ChatRoom.findByIdAndUpdate(newRoom._id, {
+                $set: { lastMessage: systemMessageContent, updatedAt: new Date() }
+            });
         }
 
         return NextResponse.json(

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
     try {
         await dbConnect();

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,21 +1,23 @@
 'use client';
 
-import { useState, useEffect, useCallback, Suspense } from 'react';
+import { useState, useEffect, useCallback, useRef, Suspense } from 'react';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
-import ChatRoomList, { MockChatRoom } from '@/components/chat/ChatRoomList';
+import ChatRoomList from '@/components/chat/ChatRoomList';
 import ChatWindow from '@/components/chat/ChatWindow';
 import { getSocket } from '@/lib/socket';
+import { IChatRoomClient } from '@/types/chat';
 
 // useSearchParams()를 사용하는 실제 페이지 컨텐츠 컴포넌트
 // Next.js 규칙: useSearchParams()는 반드시 Suspense 경계 안에서만 사용 가능!
 function ChatPageContent() {
     // 현재 선택된 채팅방 ID 상태
     const [activeRoomId, setActiveRoomId] = useState<string>('');
+    // message-received 핸들러 내 stale closure 방지용 ref (useEffect deps 없이 최신값 참조)
+    const activeRoomIdRef = useRef<string>('');
 
     // 📋 Step 9.2: 실제 DB에서 불러온 채팅방 목록을 저장하는 상태야.
-    // 이전의 MOCK_ROOMS 하드코딩을 완전히 대체함!
-    const [rooms, setRooms] = useState<MockChatRoom[]>([]);
+    const [rooms, setRooms] = useState<IChatRoomClient[]>([]);
     const [isLoadingRooms, setIsLoadingRooms] = useState<boolean>(true);
 
     // 📱 [모바일 반응형] 채팅방 목록을 보여줄지 여부를 관리하는 상태야.
@@ -32,16 +34,7 @@ function ChatPageContent() {
             const res = await fetch('/api/chat/rooms');
             const { success, data } = await res.json();
             if (success && data) {
-                // API에서 온 데이터를 MockChatRoom 인터페이스 구조에 맞게 변환!
-                // title → 상대방 닉네임(DM) 또는 방 metadata.name 활용
-                const mapped: MockChatRoom[] = data.map((room: any) => ({
-                    _id: room._id,
-                    category: room.category,
-                    title: room.metadata?.name || room.category,
-                    lastMessage: room.lastMessage || '',
-                    updatedAt: room.updatedAt,
-                }));
-                setRooms(mapped);
+                setRooms(data as IChatRoomClient[]);
             }
         } catch {
             // 목록 로드 실패 시 빈 목록 유지
@@ -65,21 +58,56 @@ function ChatPageContent() {
         }
     }, [searchParams]);
 
+    // activeRoomId 변경 시 ref도 동기화 (소켓 핸들러 stale closure 방지)
+    useEffect(() => {
+        activeRoomIdRef.current = activeRoomId;
+    }, [activeRoomId]);
+
     // Step 9.5: 실시간 채팅방 목록 동기화
-    // receive_message 소켓 이벤트를 받으면 lastMessage와 updatedAt을 실시간으로 갱신!
     useEffect(() => {
         const socket = getSocket();
+        // 개인 소켓 Room 입장 보장 — message-received 수신을 위해 반드시 필요!
+        // (Header도 join-user-room을 emit하지만, 타이밍 의존 없이 여기서도 emit)
+        if (session?.user?._id) {
+            socket.emit('join-user-room', { userId: session.user._id });
+        }
 
+        // receive_message: 소켓이 join한 방(활성 채팅방)에서만 수신됨
+        // → lastMessage/updatedAt 갱신만. unreadCount는 올리지 않음 (보고 있는 방이므로)
         const handleReceiveMessage = (message: any) => {
             setRooms(prev => {
                 const updated = prev.map(room => {
                     if (room._id === message.roomId) {
-                        // 해당 방의 마지막 메시지 및 시간 갱신
                         return { ...room, lastMessage: message.content, updatedAt: message.createdAt };
                     }
                     return room;
                 });
-                // 갱신된 방을 목록 최상단으로 이동 (최신 메시지 기준 정렬)
+                return [...updated].sort((a, b) =>
+                    new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+                );
+            });
+        };
+
+        // Step 7: message-received: 개인 소켓 Room(user-{id})으로 수신
+        // 발신자 포함 전체 참여자가 받음 (io.to 사용) → 모든 방의 lastMessage 갱신 커버
+        const handleMessageReceived = (message: any) => {
+            const isActive = message.roomId === activeRoomIdRef.current;
+            const isSender = message.sender === session?.user?._id;
+            setRooms(prev => {
+                const updated = prev.map(room => {
+                    if (room._id === message.roomId) {
+                        return {
+                            ...room,
+                            lastMessage: message.content,
+                            updatedAt: message.createdAt,
+                            // 보고 있는 방이거나 내가 보낸 메시지면 unread 증가 안 함
+                            myUnreadCount: (isActive || isSender)
+                                ? room.myUnreadCount
+                                : (room.myUnreadCount ?? 0) + 1,
+                        };
+                    }
+                    return room;
+                });
                 return [...updated].sort((a, b) =>
                     new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
                 );
@@ -87,34 +115,31 @@ function ChatPageContent() {
         };
 
         // Step 9.5: 새 채팅방이 생성되면 목록에 즉시 추가 (상대방이 DM을 시작했을 때!)
-        const handleNewRoom = (newRoom: any) => {
+        const handleNewRoom = (newRoom: IChatRoomClient) => {
             setRooms(prev => {
                 const exists = prev.some(r => r._id === newRoom._id);
                 if (exists) return prev;
-                const mapped: MockChatRoom = {
-                    _id: newRoom._id,
-                    category: newRoom.category,
-                    title: newRoom.metadata?.name || newRoom.category,
-                    lastMessage: newRoom.lastMessage || '',
-                    updatedAt: newRoom.updatedAt,
-                };
-                return [mapped, ...prev];
+                return [newRoom, ...prev];
             });
         };
 
         socket.on('receive_message', handleReceiveMessage);
+        socket.on('message-received', handleMessageReceived);
         socket.on('new-room', handleNewRoom);
 
         return () => {
             socket.off('receive_message', handleReceiveMessage);
+            socket.off('message-received', handleMessageReceived);
             socket.off('new-room', handleNewRoom);
         };
-    }, []);
+    }, [session?.user?._id]);
 
     const handleRoomClick = (id: string) => {
         setActiveRoomId(id);
         // 모바일에서 채팅방 클릭 시 목록을 숨기고 채팅창만 보여줌
         setShowListOnMobile(false);
+        // 클릭한 방의 읽지 않은 메시지 카운트 즉시 초기화
+        setRooms(prev => prev.map(r => r._id === id ? { ...r, myUnreadCount: 0 } : r));
     };
 
     const handleBackToList = () => {
@@ -137,28 +162,29 @@ function ChatPageContent() {
     const activeRoom = rooms.find(r => r._id === activeRoomId);
 
     return (
-        <div className="flex h-[calc(100vh-64px)] bg-slate-100 overflow-hidden">
+        <div className="flex h-[calc(100vh-64px)] bg-muted overflow-hidden">
             {/* 좌측 사이드바: 채팅방 리스트 영역
                 - PC(md 이상): 항상 표시 (block)
                 - 모바일: showListOnMobile 상태에 따라 표시/숨김 */}
             <div className={`
-                w-full md:w-80 bg-white border-r border-slate-200 flex flex-col shadow-sm z-10
+                w-full md:w-80 bg-background border-r border-border flex flex-col shadow-sm z-10 min-h-0 overflow-hidden
                 ${showListOnMobile ? 'flex' : 'hidden'} md:flex
             `}>
-                <div className="p-4 border-b border-slate-100">
-                    <h2 className="text-lg font-bold text-slate-800">메시지</h2>
+                <div className="p-4 border-b border-border">
+                    <h2 className="text-lg font-bold text-foreground">메시지</h2>
                 </div>
 
                 {/* Step 9.2: 로딩 상태 처리 */}
                 {isLoadingRooms ? (
-                    <div className="flex flex-col items-center justify-center flex-1 text-slate-400 gap-2">
-                        <div className="w-5 h-5 border-2 border-slate-300 border-t-slate-500 rounded-full animate-spin" />
+                    <div className="flex flex-col items-center justify-center flex-1 text-muted-foreground gap-2">
+                        <div className="w-5 h-5 border-2 border-border border-t-muted-foreground rounded-full animate-spin" />
                         <p className="text-xs">채팅방 목록 불러오는 중...</p>
                     </div>
                 ) : (
                     <ChatRoomList
                         rooms={rooms}
                         activeRoomId={activeRoomId}
+                        currentUserId={session?.user?._id || ''}
                         onRoomClick={handleRoomClick}
                     />
                 )}
@@ -180,10 +206,10 @@ function ChatPageContent() {
                         onLeaveRoom={handleLeaveRoom}
                     />
                 ) : (
-                    <div className="flex-1 flex flex-col items-center justify-center bg-slate-50/50">
-                        <div className="text-center text-slate-400">
-                            <svg className="w-16 h-16 mx-auto mb-4 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
-                            <p className="text-lg font-medium text-slate-600 mb-1">선택된 대화가 없습니다.</p>
+                    <div className="flex-1 flex flex-col items-center justify-center bg-muted/50">
+                        <div className="text-center text-muted-foreground">
+                            <svg className="w-16 h-16 mx-auto mb-4 text-muted-foreground/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
+                            <p className="text-lg font-medium text-muted-foreground mb-1">선택된 대화가 없습니다.</p>
                             <p className="text-sm">왼쪽에서 채팅방을 선택해 주세요.</p>
                         </div>
                     </div>
@@ -199,7 +225,7 @@ export default function ChatPage() {
     return (
         <Suspense fallback={
             <div className="flex h-[calc(100vh-64px)] items-center justify-center">
-                <div className="w-6 h-6 border-2 border-slate-300 border-t-slate-600 rounded-full animate-spin" />
+                <div className="w-6 h-6 border-2 border-border border-t-muted-foreground rounded-full animate-spin" />
             </div>
         }>
             <ChatPageContent />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,6 +34,8 @@ export default function Header() {
     const [isNotificationOpen, setIsNotificationOpen] = useState(false);
     const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    // 💬 Step 5: 읽지 않은 채팅 메시지 총합 상태
+    const [totalUnreadChat, setTotalUnreadChat] = useState(0);
 
     // 외부 클릭 감지용 ref
     const notificationRef = useRef<HTMLDivElement>(null);
@@ -44,17 +46,27 @@ export default function Header() {
             fetchNotifications();
 
             const socket = socketClient.connect();
-            socket.emit('join-user', session.user._id);
+            // 개인 소켓 Room 입장 (new-room, message-received 등 개인 이벤트 수신용)
+            socket.emit('join-user-room', { userId: session.user._id });
 
             const handleNewNotification = () => {
                 fetchNotifications();
                 useToastStore.getState().show('새로운 알림이 도착했습니다.', 'default');
             };
+            // 💬 Step 5: 채팅 메시지 수신 시 헤더 뱃지 카운터 증가
+            // /chat 페이지에 있거나 내가 보낸 메시지면 증가 안 함
+            const handleChatMessage = (message: any) => {
+                if (pathname?.startsWith('/chat')) return;
+                if (session?.user?._id && message.sender === session.user._id) return;
+                setTotalUnreadChat(prev => prev + 1);
+            };
 
             socket.on('new-notification', handleNewNotification);
+            socket.on('message-received', handleChatMessage);
 
             return () => {
                 socket.off('new-notification', handleNewNotification);
+                socket.off('message-received', handleChatMessage);
             };
         }
     }, [status, pathname, fetchNotifications, session]);
@@ -98,6 +110,27 @@ export default function Header() {
         }
         return () => { document.body.style.overflow = ''; };
     }, [isMobileMenuOpen]);
+
+    // 💬 Step 5: 앱 초기 로드 시 읽지 않은 채팅 메시지 총합 계산
+    useEffect(() => {
+        if (status !== 'authenticated' || !session?.user?._id) return;
+        fetch('/api/chat/rooms')
+            .then(res => res.json())
+            .then(({ success, data }) => {
+                if (success && data) {
+                    const total = (data as any[]).reduce((sum, r) => sum + (r.myUnreadCount ?? 0), 0);
+                    setTotalUnreadChat(total);
+                }
+            })
+            .catch(() => {});
+    }, [status, session?.user?._id]);
+
+    // 💬 Step 5: /chat 경로 진입 시 채팅 뱃지 초기화
+    useEffect(() => {
+        if (pathname?.startsWith('/chat')) {
+            setTotalUnreadChat(0);
+        }
+    }, [pathname]);
 
     const handleNotificationClick = async (notification: Notification) => {
         if (!notification.read) {
@@ -251,6 +284,20 @@ export default function Header() {
                             <div className="h-8 w-8 bg-muted rounded-full animate-pulse" />
                         ) : session ? (
                             <>
+                                {/* 💬 Step 5: 채팅 숏컷 버튼 */}
+                                <button
+                                    onClick={() => router.push('/chat')}
+                                    className="relative p-2 text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors"
+                                    aria-label="채팅"
+                                >
+                                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                                    </svg>
+                                    {totalUnreadChat > 0 && (
+                                        <span className="absolute top-1 right-1 block h-2 w-2 rounded-full bg-red-500 ring-2 ring-background" />
+                                    )}
+                                </button>
+
                                 {/* 알림 버튼 */}
                                 <div className="relative" ref={notificationRef}>
                                     <button

--- a/src/components/chat/ChatRoomList.tsx
+++ b/src/components/chat/ChatRoomList.tsx
@@ -2,20 +2,36 @@
 
 import { useState } from 'react';
 import { getCategoryColor, ChatCategory } from '@/constants/chat';
-
-// 💡 임시 인터페이스: 백엔드 API 연동 전에 UI를 작성하기 위한 Mock 데이터 타입이야.
-export interface MockChatRoom {
-    _id: string;
-    category: ChatCategory;
-    title: string;
-    lastMessage?: string;
-    updatedAt: string;
-}
+import { IChatRoomClient } from '@/types/chat';
 
 interface ChatRoomListProps {
-    rooms: MockChatRoom[];
+    rooms: IChatRoomClient[];
     activeRoomId?: string;
+    currentUserId: string;
     onRoomClick: (roomId: string) => void;
+}
+
+/**
+ * 💡 Step 10 (STEP 3): 채팅방 표시명 결정 유틸 함수
+ * - TEAM/INQUIRY: 프로젝트명 (API에서 채워진 projectName)
+ * - DM/RECRUIT: 상대방 닉네임 (participants 중 현재 유저가 아닌 쪽)
+ * - SYSTEM: 고정 문자열 '시스템 알림'
+ */
+function getRoomDisplayName(room: IChatRoomClient, currentUserId: string): string {
+    switch (room.category) {
+        case 'TEAM':
+        case 'INQUIRY':
+            return room.projectName || room.metadata?.name || room.category;
+        case 'DM':
+        case 'RECRUIT': {
+            const other = room.participants.find(p => p._id !== currentUserId);
+            return other?.nName || room.projectName || room.category;
+        }
+        case 'SYSTEM':
+            return '시스템 알림';
+        default:
+            return room.category;
+    }
 }
 
 /**
@@ -23,7 +39,7 @@ interface ChatRoomListProps {
  * Step 3.2: 각 아이템 왼쪽에 카테고리별 색상 인디케이터(세로 바) 추가
  * Step 4.1: 상단 필터 탭 기능을 추가해서 카테고리별로 대화방을 골라볼 수 있게 했어!
  */
-export default function ChatRoomList({ rooms, activeRoomId, onRoomClick }: ChatRoomListProps) {
+export default function ChatRoomList({ rooms, activeRoomId, currentUserId, onRoomClick }: ChatRoomListProps) {
     // 💡 Step 4.1: 현재 선택된 탭 상태를 관리. 'ALL'이면 전체 보기!
     const [activeTab, setActiveTab] = useState<ChatCategory | 'ALL'>('ALL');
 
@@ -42,9 +58,9 @@ export default function ChatRoomList({ rooms, activeRoomId, onRoomClick }: ChatR
         : rooms.filter(room => room.category === activeTab);
 
     return (
-        <div className="flex flex-col h-full">
+        <div className="flex flex-col flex-1 min-h-0">
             {/* 🏷️ Step 4.1: 카테고리 필터링 탭 영역 */}
-            <div className="px-4 py-2 border-b border-slate-100 flex gap-1 overflow-x-auto scrollbar-hide shrink-0">
+            <div className="px-4 py-2 border-b border-border flex gap-1 overflow-x-auto scrollbar-hide shrink-0">
                 {TABS.map(tab => (
                     <button
                         key={tab.id}
@@ -53,7 +69,7 @@ export default function ChatRoomList({ rooms, activeRoomId, onRoomClick }: ChatR
                             px-3 py-1.5 text-xs font-semibold rounded-full transition-colors whitespace-nowrap
                             ${activeTab === tab.id
                                 ? 'bg-slate-800 text-white'
-                                : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
+                                : 'bg-muted text-muted-foreground hover:bg-muted/80'
                             }
                         `}
                     >
@@ -64,14 +80,19 @@ export default function ChatRoomList({ rooms, activeRoomId, onRoomClick }: ChatR
 
             {/* 필터링 결과가 없을 때의 예외 처리 UI */}
             {filteredRooms.length === 0 ? (
-                <div className="flex flex-col items-center justify-center flex-1 text-slate-400 p-4 text-center">
+                <div className="flex flex-col items-center justify-center flex-1 text-muted-foreground p-4 text-center">
                     <p>해당하는 대화가 없습니다.</p>
                 </div>
             ) : (
-                <ul className="divide-y divide-slate-100 flex-1 overflow-y-auto">
+                <ul className="divide-y divide-border flex-1 overflow-y-auto bg-background dark:[color-scheme:dark]">
                     {filteredRooms.map((room) => {
                         const categoryColor = getCategoryColor(room.category);
                         const isActive = room._id === activeRoomId;
+
+                        // 💡 Step 10 (STEP 3): getRoomDisplayName() 유틸로 표시명 결정
+                        const displayName = getRoomDisplayName(room, currentUserId);
+                        const unreadCount = room.myUnreadCount ?? 0;
+                        const unreadLabel = unreadCount > 99 ? '99+' : String(unreadCount);
 
                         return (
                             <li
@@ -80,8 +101,8 @@ export default function ChatRoomList({ rooms, activeRoomId, onRoomClick }: ChatR
                                 // 🖱️ 호버 효과와 현재 활성화된 방 스타일을 다르게 줘서 UX를 높였어.
                                 className={`
                                     relative cursor-pointer transition-colors p-4
-                                    hover:bg-slate-50
-                                    ${isActive ? 'bg-slate-50' : 'bg-white'}
+                                    hover:bg-muted
+                                    ${isActive ? 'bg-primary/10' : 'bg-background'}
                                 `}
                             >
                                 {/* 🌈 카테고리 컬러 인디케이터 (왼쪽 세로 바) */}
@@ -92,10 +113,10 @@ export default function ChatRoomList({ rooms, activeRoomId, onRoomClick }: ChatR
 
                                 <div className="pl-2">
                                     <div className="flex items-center justify-between mb-1">
-                                        <h3 className="font-semibold text-slate-800 text-sm truncate pr-2">
-                                            {room.title}
+                                        <h3 className="font-semibold text-foreground text-sm truncate pr-2">
+                                            {displayName}
                                         </h3>
-                                        {/* 🏷️ 카테고리 배지 (우측 상단) */}
+                                        {/* 카테고리 배지 (우측 상단) */}
                                         <span
                                             className="text-[10px] font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
                                             style={{
@@ -108,16 +129,24 @@ export default function ChatRoomList({ rooms, activeRoomId, onRoomClick }: ChatR
                                         </span>
                                     </div>
 
-                                    <div className="flex items-center justify-between text-xs text-slate-500 mt-1">
-                                        <p className="truncate pr-4 flex-1">
-                                            {room.lastMessage || '새로운 채팅방이 생성되었습니다.'}
+                                    <div className="flex items-center justify-between text-xs text-muted-foreground mt-1">
+                                        <p className={`truncate pr-2 flex-1 ${room.category === 'SYSTEM' || room.lastMessage?.startsWith('[시스템]') ? 'italic' : ''}`}>
+                                            {room.lastMessage || '대화를 시작해보세요'}
                                         </p>
-                                        <span className="whitespace-nowrap shrink-0" suppressHydrationWarning>
-                                            {new Date(room.updatedAt).toLocaleTimeString('ko-KR', {
-                                                hour: '2-digit',
-                                                minute: '2-digit',
-                                            })}
-                                        </span>
+                                        {/* 🔴 Step 10 (STEP 3): 읽지 않은 메시지 배지 */}
+                                        <div className="flex items-center gap-1.5 shrink-0">
+                                            {unreadCount > 0 && (
+                                                <span className="bg-red-500 text-white text-xs rounded-full px-1.5 py-0.5 min-w-[20px] text-center leading-tight">
+                                                    {unreadLabel}
+                                                </span>
+                                            )}
+                                            <span className="whitespace-nowrap" suppressHydrationWarning>
+                                                {new Date(room.updatedAt).toLocaleTimeString('ko-KR', {
+                                                    hour: '2-digit',
+                                                    minute: '2-digit',
+                                                })}
+                                            </span>
+                                        </div>
                                     </div>
                                 </div>
                             </li>

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -4,15 +4,13 @@ import { useState, useEffect, useRef } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { getCategoryColor } from '@/constants/chat';
-import { MockChatRoom } from './ChatRoomList';
+import { IChatRoomClient, IChatMessageClient } from '@/types/chat';
 import { useChatSocket } from '@/hooks/useChatSocket';
 import { useModalStore } from '@/store/modalStore';
 
 interface ChatWindowProps {
-    room: MockChatRoom;
-    // 📱 [Step 8.3 - 모바일] 모바일에서 목록으로 돌아가는 콜백 함수 (PC에서는 사용 안 함)
+    room: IChatRoomClient;
     onBack?: () => void;
-    // 🚪 [Step 9.4] 채팅방 나가기 완료 후 부모에서 목록을 갱신하기 위한 콜백
     onLeaveRoom?: (roomId: string) => void;
 }
 
@@ -25,33 +23,22 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
     const { openConfirm } = useModalStore();
     const router = useRouter();
 
-    // Step 8.4 / Step 9.1: NextAuth 세션 우선. 없으면 sessionStorage 폴백 (실제 로그인 연동 후 제거 예정)
     const { data: session } = useSession();
     const [currentUserId, setCurrentUserId] = useState<string>('');
 
     useEffect(() => {
         if (session?.user?._id) {
-            // 실제 로그인 세션이 있으면 세션 ID 사용
             setCurrentUserId(session.user._id);
-        } else if (typeof window !== 'undefined') {
-            // 세션이 없으면 sessionStorage 임시 ID 사용 (추후 세션 연동 후 이 분기 제거)
-            let stored = sessionStorage.getItem('spm_mock_userId');
-            if (!stored) {
-                // MongoDB ObjectId 규격인 24자리 16진수 랜덤 생성
-                stored = [...Array(24)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
-                sessionStorage.setItem('spm_mock_userId', stored);
-            }
-            setCurrentUserId(stored);
         }
     }, [session]);
 
     // 🔌 Step 5.2 / Step 9.1: 해당 채팅방에 입장하면서 소켓 연결
-    // userId를 직접 주입해서 sessionStorage 의존 없이 실제 userId 사용!
+    // userId를 직접 주입해서 실제 userId 사용!
     const { isConnected, emit, subscribe } = useChatSocket({ roomId: room._id, userId: currentUserId });
 
     // 💬 Step 6.2: 메시지 상태 및 입력 관리
     const [messageInput, setMessageInput] = useState('');
-    const [messages, setMessages] = useState<any[]>([]);
+    const [messages, setMessages] = useState<IChatMessageClient[]>([]);
 
     // 📜 Step 8.1: 무한 스크롤(Pagination)을 위한 상태 관리
     const [nextCursor, setNextCursor] = useState<string | null>(null);
@@ -62,17 +49,16 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
 
     // ⬇️ Step 7.1: 자동 스크롤을 위한 Ref
     const scrollContainerRef = useRef<HTMLDivElement>(null);
+    // 메시지 목록 맨 아래 sentinel div — scrollIntoView로 정확히 하단 노출
+    const messagesEndRef = useRef<HTMLDivElement>(null);
     // 🔧 버그 1 수정: "실제 새 메시지가 온 경우"에만 스크롤 내리도록 shouldAutoScroll Ref 추가
     const shouldAutoScroll = useRef<boolean>(false);
 
     // ⬇️ Step 7.1: messages state가 바뀌었을 때 스크롤 로직 실행
     useEffect(() => {
-        const container = scrollContainerRef.current;
-        if (!container) return;
-
         if (shouldAutoScroll.current) {
-            // 실제 새 메시지 수신/전송 시에만 맨 아래로!
-            container.scrollTop = container.scrollHeight;
+            // sentinel div를 뷰포트 안으로 스크롤 (입력창 겹침 없이 정확하게!)
+            messagesEndRef.current?.scrollIntoView({ behavior: 'instant', block: 'end' });
             shouldAutoScroll.current = false;
         }
         // isLoadMoreAction이 true일 때 (8.1 데이터 로드) 스크롤 유지도 이쪽에서 진행
@@ -81,6 +67,8 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
 
     // 🚪 Step 9.4: 채팅방 헤더 메뉴(점세개) 열기/닫기 상태
     const [isMenuOpen, setIsMenuOpen] = useState(false);
+    // 👥 Step 8: 참여자 목록 패널 열기/닫기 상태
+    const [isParticipantsOpen, setIsParticipantsOpen] = useState(false);
 
     // 🚪 Step 9.4: 채팅방 나가기 핸들러
     const handleLeaveRoom = async () => {
@@ -257,7 +245,10 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
             if (roomId === room._id) {
                 // shouldAutoScroll.current를 true로 만들지 않으면 스크롤 안 내려감!
                 setMessages(prev => prev.map(msg => {
-                    const isMine = msg.sender === currentUserId || msg.sender?._id === currentUserId;
+                    // sender가 populate된 객체일 수도, 순수 문자열 ID일 수도 있어서 타입 가드로 ID를 안전하게 추출!
+                    const getSenderId = (sender: any): string =>
+                        typeof sender === 'string' ? sender : sender?._id ?? '';
+                    const isMine = getSenderId(msg.sender) === currentUserId;
                     if (isMine && msg.readBy && !msg.readBy.includes(readByUserId)) {
                         return { ...msg, readBy: [...msg.readBy, readByUserId] };
                     }
@@ -320,7 +311,8 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
 
                 // 5. 서버에 브로드캐스트 요청 (Socket.io)
                 // DB의 _id가 담긴 완전한 data를 날려보내야 상대방도 Key 충돌을 겪지 않음
-                emit('send_message', data);
+                // participantIds 포함 → 서버가 헤더 뱃지용 message-received 이벤트를 개인 Room으로 전달
+                emit('send_message', { ...data, participantIds: room.participants.map(p => p._id) });
             }
         } catch (error) {
             // 전송 실패 시 오프라인 큐에 보관 (재연결 시 자동 재전송)
@@ -337,18 +329,18 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
     };
 
     return (
-        <div className="flex-1 min-h-0 flex flex-col bg-slate-50/50 relative">
+        <div className="flex-1 min-h-0 flex flex-col bg-background relative">
             {/*
               🌟 상단 헤더 영역 (Step 3.3 핵심 구현 부분)
               - top border 박스로 컬러 라인을 명확하게 줬어!
               - 배경색에도 살짝 투명도를 넣어서 대화방 성격을 은은하게 인지하도록 만들었지.
             */}
             <div
-                className="flex items-center justify-between p-4 bg-white shadow-sm z-10 border-t-4"
+                className="flex items-center justify-between p-4 shadow-sm z-10 border-t-4 flex-shrink-0"
                 style={{
                     borderTopColor: categoryColor,
                     // 배경에 아주 연하게(약 3% 불투명도) 카테고리 색상을 깔아서 분위기를 맞춤
-                    backgroundColor: `color-mix(in srgb, ${categoryColor} 3%, white)`
+                    backgroundColor: `color-mix(in srgb, ${categoryColor} 3%, var(--background))`
                 }}
             >
                 <div>
@@ -357,7 +349,7 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
                         {onBack && (
                             <button
                                 onClick={onBack}
-                                className="md:hidden p-1.5 -ml-1 rounded-full hover:bg-slate-100 transition-colors text-slate-500"
+                                className="md:hidden p-1.5 -ml-1 rounded-full hover:bg-white/20 transition-colors text-white"
                                 title="목록으로"
                             >
                                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -375,21 +367,64 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
                         >
                             {room.category}
                         </span>
-                        <h2 className="text-lg font-bold text-slate-800">{room.title}</h2>
+                        {/* STEP 3에서 getRoomDisplayName() 유틸로 교체 예정 */}
+                        <h2 className="text-lg font-bold text-white">{room.projectName || room.metadata?.name || room.category}</h2>
                     </div>
+                    {/* 👥 Step 8: 참여자 수 부제목 */}
+                    <p className="text-xs text-white/60 pl-1">
+                        {room.participants.length === 2 ? '1:1 채팅' : `그룹 채팅 (${room.participants.length}명)`}
+                    </p>
                 </div>
 
                 {/* 우측 도구 모음 */}
-                <div className="flex items-center gap-3 text-slate-400">
-                    <button className="hover:text-slate-600 transition-colors">
+                <div className="flex items-center gap-3 text-white/70">
+                    <button className="hover:text-white transition-colors">
                         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
                     </button>
+
+                    {/* 👥 Step 8: 참여자 목록 버튼 */}
+                    <div className="relative">
+                        <button
+                            onClick={() => setIsParticipantsOpen(prev => !prev)}
+                            className="hover:text-white transition-colors"
+                            title="참여자 목록"
+                        >
+                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
+                        </button>
+                        {isParticipantsOpen && (
+                            <>
+                                <div className="fixed inset-0 z-10" onClick={() => setIsParticipantsOpen(false)} />
+                                <div className="absolute right-0 top-8 z-20 bg-popover border border-border rounded-xl shadow-lg overflow-hidden min-w-[200px]">
+                                    <div className="px-4 py-2 border-b border-border">
+                                        <p className="text-xs font-semibold text-muted-foreground">참여자 {room.participants.length}명</p>
+                                    </div>
+                                    <ul className="py-1">
+                                        {room.participants.map(p => (
+                                            <li key={p._id} className="flex items-center gap-2.5 px-4 py-2">
+                                                {p.avatarUrl ? (
+                                                    <img src={p.avatarUrl} className="w-7 h-7 rounded-full object-cover" alt={p.nName} />
+                                                ) : (
+                                                    <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center text-xs font-bold text-foreground">
+                                                        {p.nName?.charAt(0)?.toUpperCase() ?? '?'}
+                                                    </div>
+                                                )}
+                                                <span className="text-sm text-foreground">{p.nName ?? '알 수 없음'}</span>
+                                                {p._id === currentUserId && (
+                                                    <span className="text-xs text-muted-foreground ml-1">(나)</span>
+                                                )}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            </>
+                        )}
+                    </div>
 
                     {/* 🚪 Step 9.4: 점세개 메뉴 버튼 (채팅방 나가기 옵션 포함) */}
                     <div className="relative">
                         <button
                             onClick={() => setIsMenuOpen(prev => !prev)}
-                            className="hover:text-slate-600 transition-colors"
+                            className="hover:text-white transition-colors"
                         >
                             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" /></svg>
                         </button>
@@ -399,7 +434,7 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
                             <>
                                 {/* 바깥 클릭 시 메뉴 닫기 */}
                                 <div className="fixed inset-0 z-10" onClick={() => setIsMenuOpen(false)} />
-                                <div className="absolute right-0 top-8 z-20 bg-white border border-slate-200 rounded-xl shadow-lg py-1 min-w-[140px]">
+                                <div className="absolute right-0 top-8 z-20 bg-popover border border-border rounded-xl shadow-lg py-1 min-w-[140px]">
                                     <button
                                         onClick={handleLeaveRoom}
                                         className="w-full px-4 py-2.5 text-sm text-left text-red-500 hover:bg-red-50 transition-colors font-medium"
@@ -424,18 +459,18 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
             <div
                 ref={scrollContainerRef}
                 onScroll={handleScroll}
-                className="flex-1 min-h-0 overflow-y-auto p-6 space-y-4 scroll-smooth"
+                className="flex-1 min-h-0 overflow-y-auto p-6 space-y-4 scroll-smooth dark:[color-scheme:dark]"
             >
                 {/* 📜 Step 8.1: 무한스크롤 로딩 인디케이터 */}
                 {isLoadingMore && (
                     <div className="flex justify-center py-2">
-                        <span className="text-xs text-slate-400">이전 대화 불러오는 중...</span>
+                        <span className="text-xs text-muted-foreground">이전 대화 불러오는 중...</span>
                     </div>
                 )}
 
                 {!hasNextPage && messages.length > 0 && (
                     <div className="flex justify-center my-4">
-                        <span className="text-xs text-slate-400 bg-slate-100 px-3 py-1 rounded-full">
+                        <span className="text-xs text-muted-foreground bg-muted px-3 py-1 rounded-full">
                             대화가 시작되었습니다.
                         </span>
                     </div>
@@ -443,27 +478,40 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
 
                 {/* 💬 저장/수신된 메시지 목록 맵핑 렌더링 */}
                 {messages.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center h-full text-slate-400 opacity-50">
+                    <div className="flex flex-col items-center justify-center h-full text-muted-foreground opacity-50">
                         <p className="text-sm">아직 아무런 대화가 없어요!</p>
                         <p className="text-xs mt-1">첫 인사를 건네보세요 👋</p>
                     </div>
                 ) : (
                     messages.map((msg, idx) => {
-                        // 내가 보낸 메시지인지 판별 (sender가 populate된 객체일 수도 있고 ID 문자열일 수도 있음)
-                        const isMine = msg.sender === currentUserId || msg.sender?._id === currentUserId;
+                        // sender가 populate된 객체일 수도, 순수 문자열 ID일 수도 있어서 타입 가드로 ID를 안전하게 추출!
+                        const getSenderId = (sender: any): string =>
+                            typeof sender === 'string' ? sender : sender?._id ?? '';
+                        const senderId = getSenderId(msg.sender);
+                        const isMine = senderId === currentUserId;
+                        // participants에서 발신자 정보 조회
+                        const senderInfo = room.participants.find(p => p._id === senderId);
+                        const senderName = senderInfo?.nName ?? (isMine ? '나' : '알 수 없음');
+                        const senderAvatar = senderInfo?.avatarUrl;
 
                         return (
                             <div key={idx} className={`flex items-start gap-3 ${isMine ? 'flex-row-reverse' : ''}`}>
-                                {/* 프로필 아바타 (임시 더미 - Phase 9에서 실제 프로필 이미지로 교체 예정) */}
-                                <div className={`w-8 h-8 rounded-full shrink-0 ${isMine ? 'bg-blue-200' : 'bg-slate-200'}`} />
+                                {/* 프로필 아바타 */}
+                                {senderAvatar ? (
+                                    <img src={senderAvatar} className="w-8 h-8 rounded-full shrink-0 object-cover" alt={senderName} />
+                                ) : (
+                                    <div className={`w-8 h-8 rounded-full shrink-0 flex items-center justify-center text-xs font-bold ${isMine ? 'bg-slate-700 text-white' : 'bg-muted text-foreground'}`}>
+                                        {senderName.charAt(0).toUpperCase()}
+                                    </div>
+                                )}
                                 <div className={`flex flex-col gap-1 ${isMine ? 'items-end' : 'items-start'}`}>
-                                    <span className="text-xs text-slate-500 mx-1">{isMine ? '나' : '상대방'}</span>
+                                    <span className="text-xs text-muted-foreground mx-1">{senderName}</span>
 
                                     <div className={`flex items-end gap-1 ${isMine ? 'flex-row-reverse' : ''}`}>
                                         <div
                                             className={`p-3 rounded-2xl shadow-sm border max-w-md ${isMine
                                                 ? 'bg-slate-800 text-white rounded-tr-sm border-slate-700'
-                                                : 'bg-white text-slate-700 rounded-tl-sm border-slate-100'
+                                                : 'bg-card text-card-foreground rounded-tl-sm border-border'
                                                 }`}
                                         >
                                             <p className="text-sm leading-relaxed whitespace-pre-wrap">{msg.content}</p>
@@ -475,7 +523,7 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
                                             {isMine && (!msg.readBy || msg.readBy.length < 2) && (
                                                 <span className="text-[10px] text-yellow-500 font-bold mb-0.5">1</span>
                                             )}
-                                            <span className="text-[10px] text-slate-400 mx-1 min-w-fit" suppressHydrationWarning>
+                                            <span className="text-[10px] text-muted-foreground mx-1 min-w-fit" suppressHydrationWarning>
                                                 {new Date(msg.createdAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
                                             </span>
                                         </div>
@@ -485,12 +533,14 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
                         );
                     })
                 )}
+                {/* 스크롤 sentinel — 새 메시지 도착 시 이 div로 scrollIntoView */}
+                <div ref={messagesEndRef} />
             </div>
 
             {/* 채팅 입력창 영역 */}
-            <div className="p-4 bg-white border-t border-slate-200">
-                <div className="flex items-center gap-2 bg-slate-50 border border-slate-200 rounded-full px-4 py-2 focus-within:ring-1 focus-within:ring-slate-300 transition-shadow">
-                    <button className="text-slate-400 hover:text-slate-600 transition-colors p-1">
+            <div className="p-4 bg-background border-t border-border flex-shrink-0">
+                <div className="flex items-center gap-2 bg-muted border border-border rounded-full px-4 py-2 focus-within:ring-1 focus-within:ring-border transition-shadow">
+                    <button className="text-muted-foreground hover:text-foreground transition-colors p-1">
                         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
                     </button>
                     <input
@@ -499,7 +549,7 @@ export default function ChatWindow({ room, onBack, onLeaveRoom }: ChatWindowProp
                         onChange={(e) => setMessageInput(e.target.value)}
                         onKeyDown={handleKeyDown}
                         placeholder="메시지를 입력하세요..."
-                        className="flex-1 bg-transparent border-none focus:outline-none text-sm text-slate-700 px-2"
+                        className="flex-1 bg-transparent border-none focus:outline-none text-sm text-foreground px-2"
                     />
                     <button
                         onClick={handleSendMessage}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,33 @@
+import { ChatCategory } from '@/constants/chat';
+
+export interface IChatParticipant {
+  _id: string;
+  nName?: string;
+  avatarUrl?: string;
+}
+
+export interface IChatRoomClient {
+  _id: string;
+  category: ChatCategory;
+  participants: IChatParticipant[];
+  lastMessage?: string;
+  updatedAt: string;
+  createdAt?: string;
+  projectId?: string;
+  applicationId?: string;
+  metadata?: Record<string, any>;
+  /** STEP 2에서 API 보강 후 채워짐 */
+  myUnreadCount?: number;
+  /** STEP 2에서 API 보강 후 채워짐 (TEAM/INQUIRY 카테고리) */
+  projectName?: string;
+}
+
+export interface IChatMessageClient {
+  _id: string;
+  roomId: string;
+  sender: string | { _id: string; nName?: string; avatarUrl?: string };
+  content: string;
+  messageType?: string;
+  readBy?: string[];
+  createdAt: string;
+}


### PR DESCRIPTION
  Phase 10 — 최종 버그 수정 & 마감 폴리싱

---                                                                                                                                                 
1. 커밋 로그
                                                                                                                                                      
fix: 다크모드 CSS 변수 토큰 전면 적용 (bg-background, text-foreground 등)                                                                                                                                                                                                                               fix: 채팅 목록 스크롤바 다크모드 흰색 버그 수정
  - dark:[color-scheme:dark] 적용으로 네이티브 스크롤바도 다크 테마 반영

  feat: 헤더에 채팅 단축 버튼 추가 (읽지 않은 메시지 빨간 점 뱃지)
  - message-received 소켓 이벤트로 실시간 뱃지 카운트 증가
  - /chat 경로 진입 시 뱃지 즉시 초기화

  fix: 중복 채팅방 생성 방지 범위 확장
  - DM뿐만 아니라 RECRUIT (동일 2인), TEAM/INQUIRY (동일 projectId) 모두 기존 방 반환

  fix: lastMessage 미리보기 미표시 버그 수정
  - 방 생성 직후 시스템 메시지를 ChatRoom.lastMessage 필드에 즉시 반영

  fix: 실시간 채팅 목록 갱신 수정 (발신자 포함 전체 갱신)
  - socket.to() → io.to()로 변경, 발신자 본인도 message-received 수신
  - join-user-room 이벤트로 개인 소켓 룸 보장
  - activeRoomIdRef (useRef)로 stale closure 방지

  feat: 참여자 목록 패널 추가 (ChatWindow 헤더 우측)
  - 프로필 이미지, 닉네임, (나) 태그 표시
  - User 모델 실제 필드명(nName, avatarUrl)으로 populate 수정

  fix: 메시지 발신자 이름·아바타 실제 표시
  - room.participants에서 senderId 매칭하여 nName, avatarUrl 렌더링
  - "나"/"상대방" 하드코딩 제거, 이니셜 아바타 fallback 적용

  fix: 채팅 목록 하단 짤림 수정
  - ChatRoomList 루트: h-full → flex-1 min-h-0
  - 사이드바: min-h-0 overflow-hidden 추가

  fix: 메시지 목록 하단 짤림 수정
  - scrollTop = scrollHeight → scrollIntoView sentinel 방식으로 교체
  - 입력창 레이아웃을 브라우저가 반영한 정확한 위치로 스크롤

  chore: Render.com 슬립 방지 self-ping 추가
  - 프로덕션에서 10분마다 /api/status 자체 ping
  - render.yaml healthCheckPath 설정