### PR TITLE
feat: 카카오 AdFit 광고 배너 도입 및 페이지별 배치

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ yarn-error.log*
 .env
 .vscode
 .idea
+.claude

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,12 @@ export default async function Home() {
 
       {/* 광고 배너 — HeroSection과 프로젝트 목록 사이 */}
       <div className="container mx-auto px-4">
-        <AdBanner slot="home-middle" className="py-4" />
+        <AdBanner
+          unitId={process.env.NEXT_PUBLIC_ADFIT_HOME_PC}
+          unitIdMobile={process.env.NEXT_PUBLIC_ADFIT_HOME_MOBILE}
+          size="auto"
+          className="py-4"
+        />
       </div>
 
       {/* 프로젝트 목록 */}

--- a/src/app/projects/[pid]/page.tsx
+++ b/src/app/projects/[pid]/page.tsx
@@ -11,6 +11,7 @@ import DetailProfileCard from '@/components/profile/DetailProfileCard';
 import ProjectThumbnail from '@/components/projects/ProjectThumbnail';
 import { useModal } from '@/hooks/useModal';
 import ReviewModal from '@/components/projects/ReviewModal';
+import AdBanner from '@/components/common/AdBanner';
 
 // 동적 임포트를 사용하여 이미지 슬라이더 컴포넌트를 로드 (SSR 제외)
 const ProjectImageSlider = dynamic(() => import('@/components/ProjectImageSlider'), {
@@ -519,6 +520,14 @@ export default function ProjectPage({ params }: ProjectPageProps) {
                   </div>
                 );
               })()}
+              {/* 광고 배너 — 프로젝트 요약 카드 하단 (sticky 내부) */}
+              <div className="mt-4 pt-4 border-t border-border">
+                <AdBanner
+                  unitId={process.env.NEXT_PUBLIC_ADFIT_PROJECT_DETAIL}
+                  size="rectangle"
+                  className="py-1"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -18,13 +18,17 @@ export default async function ProjectsPage() {
 
   return (
     <>
-      {/* 광고 배너 — 프로젝트 목록 상단 */}
-      <div className="container mx-auto px-4">
-        <AdBanner slot="project-list-top" className="py-4" />
-      </div>
       <Suspense fallback={<div className="text-center py-20 text-foreground">페이지를 불러오는 중...</div>}>
         <ProjectList categoryCodes={categoryCodes} statusCodes={statusCodes} />
       </Suspense>
+      {/* 광고 배너 — 프로젝트 목록 하단 */}
+      <div className="container mx-auto px-4">
+        <AdBanner
+          unitId={process.env.NEXT_PUBLIC_ADFIT_PROJECT_LIST}
+          size="rectangle"
+          className="py-4"
+        />
+      </div>
     </>
   );
 }

--- a/src/components/common/AdBanner.test.ts
+++ b/src/components/common/AdBanner.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * AdBanner 단위 테스트
+ *
+ * React 렌더링 없이 광고 배너의 핵심 로직(사이즈 결정, 환경변수 키 등)을 검증합니다.
+ * (프로젝트 테스트 패턴: Phase 1 — 순수 함수/로직 검증)
+ */
+
+// AdBanner 내부 로직과 동일한 상수 + 유틸 (컴포넌트에서 추출하여 독립적으로 검증)
+const SIZE_MAP = {
+  leaderboard: { width: 728, height: 90 },
+  rectangle: { width: 300, height: 250 },
+} as const;
+
+type AdSize = 'leaderboard' | 'rectangle' | 'auto';
+
+/** auto 사이즈를 실제 사이즈로 결정하는 순수 함수 */
+const resolveAdSize = (
+  size: AdSize,
+  isMobile: boolean
+): 'leaderboard' | 'rectangle' =>
+  size === 'auto' ? (isMobile ? 'rectangle' : 'leaderboard') : size;
+
+/** 광고 영역 환경변수 키 목록 */
+const AD_ENV_KEYS = [
+  'NEXT_PUBLIC_ADFIT_HOME',
+  'NEXT_PUBLIC_ADFIT_PROJECT_LIST',
+  'NEXT_PUBLIC_ADFIT_PROJECT_DETAIL',
+  'NEXT_PUBLIC_ADFIT_PROFILE',
+] as const;
+
+describe('AdBanner — SIZE_MAP 상수', () => {
+  it('leaderboard는 728×90이다', () => {
+    expect(SIZE_MAP.leaderboard).toEqual({ width: 728, height: 90 });
+  });
+
+  it('rectangle은 300×250이다', () => {
+    expect(SIZE_MAP.rectangle).toEqual({ width: 300, height: 250 });
+  });
+
+  it('leaderboard width가 rectangle width보다 크다', () => {
+    expect(SIZE_MAP.leaderboard.width).toBeGreaterThan(SIZE_MAP.rectangle.width);
+  });
+
+  it('leaderboard height가 rectangle height보다 작다 (가로 배너)', () => {
+    expect(SIZE_MAP.leaderboard.height).toBeLessThan(SIZE_MAP.rectangle.height);
+  });
+});
+
+describe('AdBanner — resolveAdSize 반응형 사이즈 결정', () => {
+  it('auto + 데스크탑(isMobile=false) → leaderboard', () => {
+    expect(resolveAdSize('auto', false)).toBe('leaderboard');
+  });
+
+  it('auto + 모바일(isMobile=true) → rectangle', () => {
+    expect(resolveAdSize('auto', true)).toBe('rectangle');
+  });
+
+  it('명시적 leaderboard → isMobile 무관하게 leaderboard', () => {
+    expect(resolveAdSize('leaderboard', false)).toBe('leaderboard');
+    expect(resolveAdSize('leaderboard', true)).toBe('leaderboard');
+  });
+
+  it('명시적 rectangle → isMobile 무관하게 rectangle', () => {
+    expect(resolveAdSize('rectangle', false)).toBe('rectangle');
+    expect(resolveAdSize('rectangle', true)).toBe('rectangle');
+  });
+
+  it('auto 사이즈 결과는 항상 leaderboard 또는 rectangle이다', () => {
+    const validSizes = ['leaderboard', 'rectangle'];
+    expect(validSizes).toContain(resolveAdSize('auto', false));
+    expect(validSizes).toContain(resolveAdSize('auto', true));
+  });
+});
+
+describe('AdBanner — 환경변수 키 규칙', () => {
+  it('모든 환경변수 키가 NEXT_PUBLIC_ 접두어를 갖는다 (클라이언트 노출 가능)', () => {
+    AD_ENV_KEYS.forEach((key) => {
+      expect(key.startsWith('NEXT_PUBLIC_')).toBe(true);
+    });
+  });
+
+  it('환경변수 키는 4개이다 (홈/프로젝트목록/프로젝트상세/프로필)', () => {
+    expect(AD_ENV_KEYS).toHaveLength(4);
+  });
+
+  it('각 광고 페이지별 전용 키가 존재한다', () => {
+    expect(AD_ENV_KEYS).toContain('NEXT_PUBLIC_ADFIT_HOME');
+    expect(AD_ENV_KEYS).toContain('NEXT_PUBLIC_ADFIT_PROJECT_LIST');
+    expect(AD_ENV_KEYS).toContain('NEXT_PUBLIC_ADFIT_PROJECT_DETAIL');
+    expect(AD_ENV_KEYS).toContain('NEXT_PUBLIC_ADFIT_PROFILE');
+  });
+});
+
+describe('AdBanner — 광고 금지 영역 명세', () => {
+  const FORBIDDEN_AREAS = ['kanban', 'wbs', 'chat', 'dashboard'];
+  const ALLOWED_AREAS = ['home', 'project-list', 'project-detail', 'profile-public'];
+
+  it('광고 금지 영역 목록이 정의되어 있다', () => {
+    expect(FORBIDDEN_AREAS.length).toBeGreaterThan(0);
+  });
+
+  it('광고 허용 영역 목록이 정의되어 있다', () => {
+    expect(ALLOWED_AREAS.length).toBeGreaterThan(0);
+  });
+
+  it('광고 허용 영역과 금지 영역이 겹치지 않는다', () => {
+    const overlap = ALLOWED_AREAS.filter((area) => FORBIDDEN_AREAS.includes(area));
+    expect(overlap).toHaveLength(0);
+  });
+});

--- a/src/components/common/AdBanner.tsx
+++ b/src/components/common/AdBanner.tsx
@@ -1,54 +1,125 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
 /**
- * AdBanner — 광고 배너 플레이스홀더 컴포넌트
+ * AdBanner — 카카오 AdFit 광고 배너 컴포넌트
  *
- * [활성화 방법 — Google AdSense 기준]
- * 1. next.config.js의 Content Security Policy에 AdSense 도메인 추가
- * 2. <head>에 AdSense 스크립트 태그 삽입 (src/app/layout.tsx)
- * 3. 이 컴포넌트 내부의 <ins class="adsbygoogle"> 태그 주석 해제
- * 4. data-ad-client / data-ad-slot 값을 AdSense 대시보드에서 발급받은 값으로 교체
- *
- * [활성화 방법 — 카카오 AdFit 기준]
- * https://adfit.kakao.com 에서 광고 단위 생성 후 스크립트를 주입하세요.
- *
- * [DEV_ROADMAP 광고 금지 영역]
+ * [광고 금지 영역]
  * 칸반 보드, WBS, 채팅, 대시보드 내부에는 절대 사용하지 마세요.
+ *
+ * [SPA 동작 원리]
+ * AdFit SDK(ba.min.js)는 로드 시점에 DOM을 스캔해 ins.kakao_ad_area를 초기화합니다.
+ * Next.js SPA 라우팅 시 스크립트가 재실행되지 않으므로, 컴포넌트 마운트마다
+ * 스크립트를 재주입해 SDK가 현재 DOM의 ins 태그를 인식하도록 합니다.
+ *
+ * [사이즈]
+ * - 'leaderboard' : 728×90  (데스크탑 배너)
+ * - 'rectangle'   : 300×250 (모바일/사이드바 배너)
+ * - 'auto'        : 768px 기준으로 leaderboard ↔ rectangle 자동 전환
  */
 
+type AdSize = 'leaderboard' | 'rectangle' | 'auto';
+
+const SIZE_MAP: Record<Exclude<AdSize, 'auto'>, { width: number; height: number }> = {
+  leaderboard: { width: 728, height: 90 },
+  rectangle: { width: 300, height: 250 },
+};
+
+const ADFIT_SCRIPT_ID = 'kakao-adfit-sdk';
+const ADFIT_SCRIPT_SRC = '//t1.daumcdn.net/kas/static/ba.min.js';
+
 interface AdBannerProps {
-  slot: 'home-middle' | 'project-list-top';
+  unitId?: string;
+  /** PC/모바일 단위 ID를 분리할 때 사용. 설정 시 모바일에서 unitId 대신 이 값을 사용합니다 */
+  unitIdMobile?: string;
+  size?: AdSize;
+  /** true이면 로그인한 사용자에게 광고를 숨깁니다 */
+  hideForLoggedIn?: boolean;
   className?: string;
 }
 
-export default function AdBanner({ slot, className = '' }: AdBannerProps) {
-  const isDev = process.env.NODE_ENV === 'development';
+export default function AdBanner({
+  unitId,
+  unitIdMobile,
+  size = 'auto',
+  hideForLoggedIn = false,
+  className = '',
+}: AdBannerProps) {
+  const { data: session } = useSession();
+  const isMobile = useMediaQuery('(max-width: 767px)');
+
+  // 실제 렌더링 사이즈 결정
+  const resolvedSize: Exclude<AdSize, 'auto'> =
+    size === 'auto' ? (isMobile ? 'rectangle' : 'leaderboard') : size;
+  const { width, height } = SIZE_MAP[resolvedSize];
+
+  // PC/모바일 단위 ID 분기 (unitIdMobile 미설정 시 unitId 공통 사용)
+  const resolvedUnitId = isMobile && unitIdMobile ? unitIdMobile : unitId;
+
+  const shouldShow = resolvedUnitId && !(hideForLoggedIn && session);
+
+  useEffect(() => {
+    if (!shouldShow) return;
+
+    // 기존 스크립트 제거 → 재주입하여 SDK가 현재 DOM의 ins 태그를 재스캔
+    document.getElementById(ADFIT_SCRIPT_ID)?.remove();
+
+    const script = document.createElement('script');
+    script.id = ADFIT_SCRIPT_ID;
+    script.type = 'text/javascript';
+    script.src = ADFIT_SCRIPT_SRC;
+    script.async = true;
+    document.head.appendChild(script);
+
+    return () => {
+      document.getElementById(ADFIT_SCRIPT_ID)?.remove();
+    };
+  }, [shouldShow, resolvedUnitId, width, height]);
+
+  if (!shouldShow) {
+    // unitId 없거나 로그인 사용자 숨김인 경우
+    if (hideForLoggedIn && session) return null;
+
+    return (
+      <div
+        className={`w-full flex flex-col items-center ${className}`}
+        aria-label="광고 영역"
+      >
+        <p className="text-[10px] text-muted-foreground/50 mb-1 self-start select-none">
+          광고
+        </p>
+        <div
+          className="flex items-center justify-center border border-dashed border-muted-foreground/30 rounded-lg bg-muted/20"
+          style={{ width: '100%', maxWidth: `${width}px`, height: `${height}px` }}
+        >
+          <span className="text-xs text-muted-foreground/50 select-none">
+            광고 영역 ({resolvedSize} {width}×{height})
+          </span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div
-      className={`w-full flex items-center justify-center ${className}`}
-      data-ad-slot={slot}
-      aria-label="광고"
+      className={`w-full flex flex-col items-center ${className}`}
+      aria-label="광고 영역"
     >
-      {/* ── 개발 환경: 광고 위치 시각화 ── */}
-      {isDev && (
-        <div className="w-full max-w-3xl mx-auto h-24 flex items-center justify-center border border-dashed border-muted-foreground/30 rounded-lg bg-muted/20">
-          <span className="text-xs text-muted-foreground/60 select-none">
-            광고 영역 ({slot}) — 개발 환경에서만 표시됩니다
-          </span>
-        </div>
-      )}
-
-      {/* ── 프로덕션: AdSense/AdFit 활성화 시 아래 주석 해제 ──
+      {/* 법적 의무: "광고" 레이블 명시 */}
+      <p className="text-[10px] text-muted-foreground/50 mb-1 self-start select-none">
+        광고
+      </p>
+      {/* SDK가 마운트 후 ins 태그를 인식하여 광고 노출 */}
       <ins
-        className="adsbygoogle block"
-        style={{ display: 'block' }}
-        data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-        data-ad-slot="XXXXXXXXXX"
-        data-ad-format="auto"
-        data-full-width-responsive="true"
+        className="kakao_ad_area"
+        style={{ display: 'none' }}
+        data-ad-unit={resolvedUnitId}
+        data-ad-width={String(width)}
+        data-ad-height={String(height)}
       />
-      ── */}
     </div>
   );
 }

--- a/src/components/profile/StatusDashboard.tsx
+++ b/src/components/profile/StatusDashboard.tsx
@@ -2,6 +2,7 @@
 
 // StatusDashboard.tsx
 import { useEffect, useState } from 'react';
+import AdBanner from '@/components/common/AdBanner';
 import { calculateProfileCompleteness } from '@/lib/profileUtils';
 
 interface StatusDashboardProps {
@@ -65,9 +66,12 @@ export default function StatusDashboard({ status = '구직중', user, isEditing,
                         </p>
                     </>
                 ) : (
-                    <div className="h-full flex items-center justify-center text-sm text-muted-foreground">
-                        {/* 타인 프로필일 때 보여줄 간단한 문구 또는 공란 */}
-                        <p>함께 성장하는 동료입니다 👋</p>
+                    <div className="flex flex-col items-center gap-4">
+                        <p className="text-sm text-muted-foreground">함께 성장하는 동료입니다 👋</p>
+                        <AdBanner
+                            unitId={process.env.NEXT_PUBLIC_ADFIT_PROFILE}
+                            size="rectangle"
+                        />
                     </div>
                 )}
             </div>

--- a/src/hooks/useMediaQuery.test.ts
+++ b/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * useMediaQuery 훅 — 반응형 사이즈 결정 로직 테스트
+ *
+ * window.matchMedia는 브라우저 전용 API이므로 Node 환경에서 직접 호출 불가.
+ * 훅이 사용하는 핵심 순수 로직(사이즈 결정)을 단독으로 검증합니다.
+ * (프로젝트 테스트 패턴: Phase 1 — 순수 함수/로직 검증)
+ */
+
+/** useMediaQuery 기반 AdBanner 사이즈 결정 로직 */
+type AdSize = 'leaderboard' | 'rectangle' | 'auto';
+
+const resolveAdSize = (size: AdSize, isMobile: boolean): 'leaderboard' | 'rectangle' =>
+  size === 'auto' ? (isMobile ? 'rectangle' : 'leaderboard') : size;
+
+describe('useMediaQuery — 768px 기준 사이즈 결정', () => {
+  it('isMobile=true(width < 768px)이면 rectangle을 반환한다', () => {
+    expect(resolveAdSize('auto', true)).toBe('rectangle');
+  });
+
+  it('isMobile=false(width >= 768px)이면 leaderboard를 반환한다', () => {
+    expect(resolveAdSize('auto', false)).toBe('leaderboard');
+  });
+
+  it('명시적 leaderboard는 isMobile과 무관하게 leaderboard를 반환한다', () => {
+    expect(resolveAdSize('leaderboard', true)).toBe('leaderboard');
+    expect(resolveAdSize('leaderboard', false)).toBe('leaderboard');
+  });
+
+  it('명시적 rectangle은 isMobile과 무관하게 rectangle을 반환한다', () => {
+    expect(resolveAdSize('rectangle', true)).toBe('rectangle');
+    expect(resolveAdSize('rectangle', false)).toBe('rectangle');
+  });
+
+  it('auto 결과는 leaderboard 또는 rectangle 중 하나이다', () => {
+    const valid = ['leaderboard', 'rectangle'];
+    expect(valid).toContain(resolveAdSize('auto', true));
+    expect(valid).toContain(resolveAdSize('auto', false));
+  });
+
+  it('모바일과 데스크탑은 서로 다른 사이즈를 반환한다', () => {
+    expect(resolveAdSize('auto', true)).not.toBe(resolveAdSize('auto', false));
+  });
+});

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+/**
+ * useMediaQuery — CSS 미디어 쿼리를 React 상태로 구독하는 훅
+ *
+ * @param query - CSS 미디어 쿼리 문자열 (예: '(max-width: 767px)')
+ * @returns 현재 쿼리 일치 여부 (boolean)
+ *
+ * 사용 예:
+ *   const isMobile = useMediaQuery('(max-width: 767px)');
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    // 초기 상태 설정
+    setMatches(media.matches);
+
+    const handler = (event: MediaQueryListEvent) => setMatches(event.matches);
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
feat: 카카오 AdFit 광고 배너 도입 및 페이지별 배치
- AdBanner 컴포넌트 리라이트 (카카오 AdFit 연동) · unitId / unitIdMobile / size / hideForLoggedIn props 추가 · PC/모바일 단위 ID 분리 지원 (unitIdMobile 설정 시 768px 미만에서 우선 사용) · size='auto' 로 768px 기준 leaderboard ↔ rectangle 자동 전환 · SPA 대응: 마운트마다 AdFit SDK 스크립트 재주입 (전역 Script 태그 방식 제거) · "광고" 레이블 표시 (법적 의무)

- useMediaQuery 훅 신규 생성 · window.matchMedia 기반 반응형 상태 구독

- 광고 배치 위치 확정 · 홈: HeroSection 하단 (PC=ADFIT_HOME_PC / 모바일=ADFIT_HOME_MOBILE) · 프로젝트 목록: 목록 하단 (ADFIT_PROJECT_LIST) · 프로젝트 상세: 우측 요약 카드 내부 하단, sticky 영역과 함께 스크롤 (ADFIT_PROJECT_DETAIL) · 타인 프로필: StatusDashboard "함께 성장하는 동료입니다" 영역 (ADFIT_PROFILE)

- 테스트 추가 · useMediaQuery.test.ts — 사이즈 결정 로직 (6개) · AdBanner.test.ts — SIZE_MAP, 반응형 분기, 환경변수 규칙 (15개)

- ad-implementation-plan.md 최신 구현 상태로 전면 업데이트