### PR TITLE
fix: API 크레딧 부족 시 workflow 실패 대신 경고로 graceful 처리

### DIFF
--- a/scripts/generate-worklog.py
+++ b/scripts/generate-worklog.py
@@ -54,6 +54,19 @@ try:
         content = result['content'][0]['text']
 except urllib.error.HTTPError as e:
     error_body = e.read().decode('utf-8')
+    try:
+        error_json = json.loads(error_body)
+        error_type = error_json.get('error', {}).get('type', '')
+        error_msg = error_json.get('error', {}).get('message', '')
+    except Exception:
+        error_type = ''
+        error_msg = error_body
+
+    if error_type == 'invalid_request_error' and 'credit' in error_msg.lower():
+        print(f"⚠️ Anthropic API 크레딧 부족으로 work-log 자동 생성을 건너뜁니다.")
+        print(f"   Plans & Billing에서 크레딧을 충전해주세요.")
+        sys.exit(0)
+
     print(f"❌ Anthropic API 오류 {e.code}: {error_body}", file=sys.stderr)
     sys.exit(1)
 


### PR DESCRIPTION
크레딧 부족(invalid_request_error)은 코드 오류가 아니므로
exit(1) 대신 경고 메시지 출력 후 exit(0)으로 종료

## 작업 요약

<!-- 이 PR에서 무엇을 했는지 한 줄로 설명해주세요 -->

## 변경된 파일 및 내용

## <!-- 주요 변경 파일과 변경 이유를 작성해주세요 -->

## 미완성 / 다음 세션에서 이어받을 부분

<!-- 이번 PR에서 완료하지 못한 부분이 있으면 작성해주세요 -->

없음

## 건드리면 안 되는 부분

<!-- 다른 팀원이 이 코드를 수정할 때 주의해야 할 부분이 있으면 작성해주세요 -->

없음

## 체크리스트

- [ ] `'use client'` 선언 확인 (클라이언트 컴포넌트)
- [ ] API Route에 `dynamic = 'force-dynamic'` + `dbConnect()` 호출 확인
- [ ] 응답 형식 `{ success, data | message | error }` 통일 확인
- [ ] `.workzones.yml` 업데이트 (작업 구역 변경 시)
- [ ] `npm run lint` 경고 확인

## 사용한 AI 모델

<!-- 바이브코딩 시 사용한 모델을 기록해주세요 -->

- [ ] Claude
- [ ] Gemini
- [ ] 직접 작성
