### PR TITLE
chore: SPM 스킬 체계 개편 및 GitHub Actions CI 수정

### DIFF
--- a/work-logs/2026-03-29-HyunJin-c3377f0.md
+++ b/work-logs/2026-03-29-HyunJin-c3377f0.md
@@ -1,0 +1,37 @@
+## 2026-03-29 — HyunJin (180-spm-improve) `c3377f0`
+
+> 모델: claude (spm-done 자동생성)
+
+## 작업 요약
+
+SPM 스킬 체계를 단일 커맨드에서 4개 커맨드(spm-start/commit/done/revert)로 분리하고, GitHub CLI 연동 및 CI 워크플로우 오류를 수정했다.
+
+## 변경된 파일
+
+- `.claude/skills/spm-start/SKILL.md` — 신규: gh CLI 기반 이슈 생성·브랜치 생성·충돌 감지 포함 작업 시작 커맨드
+- `.claude/skills/spm-commit/SKILL.md` — 신규: 테스트 강제화 + AI 커밋 메시지 생성 중간 커밋 커맨드
+- `.claude/skills/spm-done/SKILL.md` — 신규: 테스트 검증 + work-log 생성 + PR 자동 생성 + 문서 갱신 종료 커맨드
+- `.claude/skills/spm-revert/SKILL.md` — 신규: work-log 기반 충돌 안내 + gh pr create 롤백 커맨드
+- `.claude/skills/spm/SKILL.md` — 기존 단일 스킬을 하위 호환 진입점으로 축소
+- `.github/workflows/auto-worklog.yml` — Python heredoc YAML 파서 충돌 수정 (스크립트 분리), push 트리거 비활성화 (spm-done으로 대체)
+- `.github/workflows/ci.yml` — typecheck job의 누락된 `run: npx tsc --noEmit` 추가
+- `.prettierignore` — 자동생성 HTML 리포트 파일 패턴 추가
+- `.prettierrc` / `render.yaml` / `src/store/MAP.md` — prettier 포맷 정리
+- `.workzones.yml` — git rm --cached로 Git 추적 해제 (로컬 전용)
+- `docs/plans/SPM_IMPROVEMENT_PLAN.md` — SPM 개선 계획서 추가
+- `scripts/generate-worklog.py` — auto-worklog.yml에서 분리된 Python 스크립트 (크레딧 부족 graceful 처리 포함)
+
+## 테스트 결과
+
+- 실행 명령: `npm run test:run`
+- 결과: 646 passed / 0 failed (49 files)
+- 신규 추가 테스트: 0개 (스킬/설정 파일 작업으로 앱 로직 변경 없음)
+- 미작성 테스트 및 사유: 없음
+
+## 건드리면 안 되는 부분
+
+없음 (이번 작업은 스킬 파일·CI 워크플로우·설정 파일만 수정, 앱 로직 미접촉)
+
+## 미완성 / 다음 세션에서 이어받을 부분
+
+없음


### PR DESCRIPTION
## 작업 요약
SPM 스킬을 단일 커맨드에서 spm-start/commit/done/revert 4개로 분리하고, GitHub CLI 연동 및 CI 워크플로우 오류를 수정했다.

## 주요 변경사항
- `/spm-start`: gh CLI 기반 이슈·브랜치 자동 생성, 팀원 충돌 감지, 미종료 작업 감지
- `/spm-commit`: 테스트 강제화 + AI 커밋 메시지
- `/spm-done`: work-log 생성 + gh pr create + 문서 자동 갱신
- `/spm-revert`: work-log 기반 충돌 안내 + revert PR 자동 생성
- `ci.yml`: typecheck step 누락 run 명령 추가
- `auto-worklog.yml`: Python 스크립트 분리, push 트리거 비활성화 (spm-done으로 대체)
- `.workzones.yml`: git rm --cached로 Git 추적 해제 (로컬 전용)

## 테스트 결과
- 646 passed / 0 failed (49 files)

Closes #180