### PR TITLE
fix: ESLint Warning 42건 수정 및 lint-staged ESLint 활성화

### DIFF
--- a/work-logs/2026-03-29-FFLINA-PC-3c12f75.md
+++ b/work-logs/2026-03-29-FFLINA-PC-3c12f75.md
@@ -1,0 +1,53 @@
+## 2026-03-29 — FFLINA-PC (feature/193-eslint-improve) `3c12f75`
+
+> 모델: claude (spm-done 자동생성)
+
+## 작업 요약
+
+ESLint Warning 42건 수정 및 lint-staged ESLint 활성화, 코드 품질 개선
+
+## 변경된 파일
+
+- `.lintstagedrc.js` — lint-staged ESLint 검사 활성화
+- `CLAUDE.md` — 현재 진행 중 작업 현황 표 갱신
+- `src/app/api/chat/messages/[roomId]/route.ts` — ESLint prefer-const 워닝 수정
+- `src/app/api/chat/rooms/route.ts` — ESLint prefer-const, exhaustive-deps 워닝 수정
+- `src/app/api/users/blog/posts/route.ts` — ESLint 워닝 수정
+- `src/app/api/users/me/availability/route.ts` — ESLint 워닝 수정
+- `src/app/dashboard/[pid]/page.tsx` — exhaustive-deps 워닝 수정
+- `src/app/projects/[pid]/page.tsx` — exhaustive-deps 워닝 수정
+- `src/components/admin/AdminDashboard.tsx` — ESLint 워닝 수정
+- `src/components/admin/AdminProjectDetailModal.tsx` — ESLint 워닝 수정
+- `src/components/admin/AdminUserDetailModal.tsx` — ESLint 워닝 수정
+- `src/components/admin/TechStackManager.tsx` — ESLint 워닝 수정
+- `src/components/board/BoardShell.tsx` — ESLint 워닝 수정
+- `src/components/board/ShortcutHandler.tsx` — unused import 제거
+- `src/components/chat/ChatWindow.tsx` — ESLint 워닝 수정
+- `src/components/dashboard/MemberWidget.tsx` — ESLint 워닝 수정
+- `src/components/dashboard/ResourceModal.tsx` — ESLint 워닝 수정
+- `src/components/profile/*.tsx` — ESLint 워닝 일괄 수정 (7개 파일)
+- `src/components/projects/ProjectList.tsx` — ESLint 워닝 수정
+- `src/components/projects/ProjectThumbnail.tsx` — ESLint 워닝 수정
+- `src/components/projects/ReviewModal.tsx` — ESLint 워닝 수정
+- `src/lib/github/service.ts` — ESLint 워닝 수정
+- `src/lib/socket.ts` — prefer-const 워닝 수정
+- `src/lib/utils/wbs/drawDependencies.ts` — ESLint 워닝 수정
+
+## 테스트 결과
+
+- 실행 명령: `npm run test:run`
+- 결과: 659 passed / 0 failed
+- 신규 추가 테스트: 0개
+- 미작성 테스트 및 사유: 없음 (ESLint 워닝 수정은 동작 변경 없음)
+
+## 건드리면 안 되는 부분
+
+| 파일 | 위치 | 이유 |
+| --- | --- | --- |
+| src/lib/socket.ts | socket 초기화 로직 | 실시간 동기화 기반, 변경 시 전체 Socket 통신 영향 |
+| src/lib/utils/wbs/drawDependencies.ts | SVG 렌더링 로직 | 성능 최적화된 DOM 직접 조작 코드 |
+| src/components/board/ShortcutHandler.tsx | 키보드 이벤트 핸들러 | 칸반 조작과 강하게 결합된 로직 |
+
+## 미완성 / 다음 세션에서 이어받을 부분
+
+없음


### PR DESCRIPTION
### 변경 사항
- ESLint Warning 42건 수정 (prefer-const, exhaustive-deps, no-unescaped-entities)
- lint-staged에 ESLint 검사 활성화
- 코드 품질 개선 (37개 파일, +507/-160)

### 테스트
- npm run test:run: 659 passed / 0 failed

Closes #193