### PR TITLE
hotfix: 대시보드 진입 시 author/_id TypeError 수정

### DIFF
--- a/src/app/api/admin/projects/[pid]/route.ts
+++ b/src/app/api/admin/projects/[pid]/route.ts
@@ -23,7 +23,7 @@ async function handleGet(_request: NextRequest, { params }: { params: { pid: str
     }
 
     const project = await Project.findOne({ pid })
-      .populate('author', 'nName authorEmail avatarUrl')
+      .populate('ownerId', 'nName authorEmail avatarUrl')
       .populate('tags', 'name logoUrl category')
       .lean();
 
@@ -74,7 +74,7 @@ async function handlePatch(request: NextRequest, { params }: { params: { pid: st
     }
 
     const updated = await Project.findOneAndUpdate({ pid }, { $set: { delYn } }, { new: true })
-      .populate('author', 'nName authorEmail avatarUrl')
+      .populate('ownerId', 'nName authorEmail avatarUrl')
       .populate('tags', 'name logoUrl category');
 
     if (!updated) {

--- a/src/app/api/kanban/boards/[boardId]/members/route.ts
+++ b/src/app/api/kanban/boards/[boardId]/members/route.ts
@@ -28,27 +28,19 @@ async function handleGet(request: Request, { params }: { params: { boardId: stri
     }
 
     // 3. 프로젝트 및 멤버 조회
-    // Project 모델의 virtual populate 'projectMembers'를 사용하거나,
-    // 직접 ProjectMember 컬렉션을 조회할 수도 있지만,
-    // Project 모델 조회 시 populate 옵션을 사용하는 것이 효율적일 수 있음.
-    // 기존 /api/projects/[pid] 참조.
-
-    const project = await Project.findOne({ pid: board.pid }).populate({
-      path: 'projectMembers',
-      populate: {
-        path: 'userId', // User 모델 populate
-        select: 'nName authorEmail position avatarUrl', // 필요한 필드만 선택 (avatarUrl 추가)
-      },
-    });
+    const project = await Project.findOne({ pid: board.pid })
+      .populate({
+        path: 'members.userId',
+        select: 'nName authorEmail position avatarUrl',
+      })
+      .lean();
 
     if (!project) {
       return NextResponse.json({ error: 'Project not found' }, { status: 404 });
     }
 
     // 4. 멤버 데이터 가공
-    // project.projectMembers는 가상 필드로 populate 된 상태
-    // (타입스크립트 이슈가 있을 수 있어 any로 캐스팅하거나 방어코드 작성)
-    interface PopulatedProjectMember {
+    interface PopulatedMember {
       userId: {
         _id: string;
         nName: string;
@@ -59,18 +51,17 @@ async function handleGet(request: Request, { params }: { params: { boardId: stri
       role: string;
     }
 
-    const projectWithMembers = project as typeof project & {
-      projectMembers?: PopulatedProjectMember[];
-    };
-    const members =
-      projectWithMembers.projectMembers?.map((pm: PopulatedProjectMember) => ({
-        _id: pm.userId._id, // User ID (assigneeId로 사용될 값)
+    const projectData = project as unknown as { members?: PopulatedMember[] };
+    const members = (projectData.members || [])
+      .filter((pm) => pm.userId)
+      .map((pm) => ({
+        _id: pm.userId._id,
         nName: pm.userId.nName,
         email: pm.userId.authorEmail,
         position: pm.userId.position,
-        avatarUrl: pm.userId.avatarUrl, // 아바타 URL 추가
-        role: pm.role, // Member role (editor, viewer etc)
-      })) || [];
+        avatarUrl: pm.userId.avatarUrl,
+        role: pm.role,
+      }));
 
     return NextResponse.json({ success: true, members });
   } catch (error) {

--- a/src/app/dashboard/[pid]/layout.tsx
+++ b/src/app/dashboard/[pid]/layout.tsx
@@ -13,8 +13,8 @@ interface ProjectMember {
 
 interface ProjectData {
   _id: string;
-  author: { _id: string };
-  projectMembers: ProjectMember[];
+  ownerId: { _id: string };
+  members: ProjectMember[];
 }
 
 /**
@@ -188,8 +188,8 @@ export default function DashboardLayout({
 
           const project = data.data as ProjectData;
           const userId = session.user.id;
-          const isAuthor = project.author._id === userId;
-          const isMember = project.projectMembers.some(
+          const isAuthor = project.ownerId._id === userId;
+          const isMember = project.members.some(
             (m) => m.userId._id === userId && m.status === 'active'
           );
 

--- a/src/app/dashboard/[pid]/page.tsx
+++ b/src/app/dashboard/[pid]/page.tsx
@@ -27,11 +27,11 @@ interface ResourceMetadata {
 }
 
 // 프로젝트 데이터 타입 확장
-interface PopulatedProject extends Omit<IProject, 'tags' | 'author'> {
-  author: { _id: string; nName: string } | string;
+interface PopulatedProject extends Omit<IProject, 'tags' | 'ownerId' | 'members'> {
+  ownerId: { _id: string; nName: string } | string;
   tags: { _id: string; name: string; category: string }[];
   likesCount: number;
-  projectMembers?: PopulatedProjectMember[];
+  members: PopulatedProjectMember[];
 }
 
 import ProjectHeader from '@/components/dashboard/ProjectHeader';
@@ -228,10 +228,10 @@ export default function DashboardPage({ params }: { params: { pid: string } }) {
 
   // ✨ 팀 채팅방 입장/생성 핸들러
   const handleTeamChat = async () => {
-    if (!project || !project.projectMembers) return;
+    if (!project || !project.members) return;
 
     // 현재 프로젝트의 모든 멤버 ID 추출 (본인 포함)
-    const memberIds = project.projectMembers
+    const memberIds = project.members
       .map((pm: PopulatedProjectMember) => pm.userId?._id)
       .filter((id): id is string => !!id);
 
@@ -286,7 +286,7 @@ export default function DashboardPage({ params }: { params: { pid: string } }) {
   if (!project) return <div className="p-8">프로젝트를 찾을 수 없습니다.</div>;
 
   // 작성자 권한 확인
-  const authorId = typeof project.author === 'string' ? project.author : project.author._id;
+  const authorId = typeof project.ownerId === 'string' ? project.ownerId : project.ownerId._id;
   const userId = session?.user?._id;
   const isAuthor = userId === authorId;
 
@@ -325,7 +325,7 @@ export default function DashboardPage({ params }: { params: { pid: string } }) {
           {/* Member List Widget (Real-time) */}
           {project && session?.user && (
             <MemberWidget
-              members={(project.projectMembers || [])
+              members={(project.members || [])
                 .filter((pm: PopulatedProjectMember) => pm.userId?._id)
                 .map((pm: PopulatedProjectMember) => ({
                   _id: pm.userId!._id,

--- a/src/app/dashboard/[pid]/wbs/page.tsx
+++ b/src/app/dashboard/[pid]/wbs/page.tsx
@@ -35,7 +35,9 @@ export default function WBSPage({ params }: { params: { pid: string } }) {
     cleanupSocket,
   } = useWbsStore();
 
-  const [projectMembers, setProjectMembers] = useState<any[]>([]);
+  const [projectMembers, setProjectMembers] = useState<
+    { _id: string; nName: string; email: string; role: string }[]
+  >([]);
   const [panelTask, setPanelTask] = useState<Task | null>(null); // TaskPanel에 표시할 작업
   const [isPanelOpen, setIsPanelOpen] = useState(false);
 
@@ -55,6 +57,7 @@ export default function WBSPage({ params }: { params: { pid: string } }) {
     return () => {
       cleanupSocket();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- initSocket/cleanupSocket는 store 메서드로 안정적; deps에 넣으면 소켓 재연결 반복
   }, [status, projectId]);
 
   // 프로젝트 작업 목록 및 멤버 정보 가져오기
@@ -71,13 +74,13 @@ export default function WBSPage({ params }: { params: { pid: string } }) {
         if (!data.success || !data.data) return;
 
         const project = data.data;
-        const members: any[] = [];
+        const members: { _id: string; nName: string; email: string; role: string }[] = [];
 
-        if (project.author) {
+        if (project.ownerId) {
           members.push({
-            _id: project.author._id,
-            nName: project.author.nName || project.author.email,
-            email: project.author.email,
+            _id: project.ownerId._id,
+            nName: project.ownerId.nName || project.ownerId.authorEmail,
+            email: project.ownerId.authorEmail,
             role: '프로젝트 리더',
           });
         }
@@ -87,9 +90,14 @@ export default function WBSPage({ params }: { params: { pid: string } }) {
           const applicationsData = await applicationsRes.json();
 
           if (applicationsData.success && applicationsData.data) {
+            interface ApplicationData {
+              status: string;
+              applicantId: { _id: string; nName?: string; email?: string };
+              role: string;
+            }
             const acceptedApplicants = applicationsData.data
-              .filter((app: any) => app.status === 'accepted')
-              .map((app: any) => ({
+              .filter((app: ApplicationData) => app.status === 'accepted')
+              .map((app: ApplicationData) => ({
                 _id: app.applicantId._id || app.applicantId,
                 nName: app.applicantId.nName || app.applicantId.email,
                 email: app.applicantId.email,
@@ -132,9 +140,9 @@ export default function WBSPage({ params }: { params: { pid: string } }) {
   // TaskPanel 저장 핸들러
   const handlePanelSave = async (data: TaskFormData) => {
     if (panelTask) {
-      await updateTask(panelTask.id, data as any);
+      await updateTask(panelTask.id, data as unknown as Partial<Omit<Task, 'id'>>);
     } else {
-      await addTask(data as any);
+      await addTask(data as unknown as Omit<Task, 'id'>);
     }
     closePanel();
   };

--- a/src/app/projects/[pid]/manage/page.tsx
+++ b/src/app/projects/[pid]/manage/page.tsx
@@ -30,7 +30,24 @@ export default function ManageApplicantsPage() {
   const { alert, confirm } = useModal();
 
   // 상태 관리
-  const [project, setProject] = useState<any>(null); // 프로젝트 정보 (멤버 포함)
+  interface ProjectWithMembers {
+    _id: string;
+    members: {
+      _id?: string;
+      userId: {
+        _id: string;
+        nName?: string;
+        position?: string;
+        career?: string;
+        level?: number;
+        techTags?: string[];
+        avatarUrl?: string;
+      };
+      role: string;
+      status: string;
+    }[];
+  }
+  const [project, setProject] = useState<ProjectWithMembers | null>(null); // 프로젝트 정보 (멤버 포함)
   const [applications, setApplications] = useState<Application[]>([]); // 지원자 목록
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -48,8 +65,8 @@ export default function ManageApplicantsPage() {
       } else {
         throw new Error(data.message || '지원자 목록을 불러오는데 실패했습니다.');
       }
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : '알 수 없는 오류');
     }
   }, [pid]);
 
@@ -100,8 +117,8 @@ export default function ManageApplicantsPage() {
       } else {
         throw new Error(data.message || '상태 변경에 실패했습니다.');
       }
-    } catch (err: any) {
-      await alert('에러', err.message);
+    } catch (err: unknown) {
+      await alert('에러', err instanceof Error ? err.message : '알 수 없는 오류');
     }
   };
 
@@ -122,8 +139,8 @@ export default function ManageApplicantsPage() {
         } else {
           throw new Error(data.message);
         }
-      } catch (err: any) {
-        await alert('에러', err.message);
+      } catch (err: unknown) {
+        await alert('에러', err instanceof Error ? err.message : '알 수 없는 오류');
       }
     }
   };
@@ -137,13 +154,13 @@ export default function ManageApplicantsPage() {
       <h1 className="text-3xl font-bold mb-8 text-foreground">프로젝트 관리</h1>
 
       {/* 1. 현재 참여 멤버 섹션 */}
-      {project && project.projectMembers && project.projectMembers.length > 0 && (
+      {project && project.members && project.members.length > 0 && (
         <div className="mb-12">
           <h2 className="text-xl font-bold mb-4 text-foreground">
-            현재 참여 멤버 ({project.projectMembers.length}명)
+            현재 참여 멤버 ({project.members.length}명)
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {project.projectMembers.map((pm: any) => {
+            {project.members.map((pm) => {
               const user = pm.userId;
               if (!user) return null;
               return (
@@ -214,7 +231,7 @@ export default function ManageApplicantsPage() {
                           category: 'RECRUIT',
                           participants: [app.applicantId._id],
                           applicationId: app._id,
-                          projectId: project._id, // 🔥 프로젝트의 실제 ObjectId (_id)로 수정
+                          projectId: project?._id, // 🔥 프로젝트의 실제 ObjectId (_id)로 수정
                         }),
                       });
                       const data = await res.json();
@@ -226,8 +243,11 @@ export default function ManageApplicantsPage() {
                           : data.message || '채팅방 생성 실패';
                         await alert('오류', errorMsg);
                       }
-                    } catch (e: any) {
-                      await alert('오류', `요청 중 문제가 발생했습니다.\n${e.message}`);
+                    } catch (e: unknown) {
+                      await alert(
+                        '오류',
+                        `요청 중 문제가 발생했습니다.\n${e instanceof Error ? e.message : '알 수 없는 오류'}`
+                      );
                     }
                   }}
                   className="px-3 py-1 text-sm bg-blue-100 text-blue-600 rounded hover:bg-blue-200 transition-colors flex items-center gap-1"

--- a/src/components/admin/AdminProjectDetailModal.tsx
+++ b/src/components/admin/AdminProjectDetailModal.tsx
@@ -28,7 +28,7 @@ interface ProjectDetail {
   images: string[];
   members: { role: string; current: number; max: number }[];
   tags: TagDetail[];
-  author: { _id: string; nName: string; authorEmail: string; avatarUrl?: string } | null;
+  ownerId: { _id: string; nName: string; authorEmail: string; avatarUrl?: string } | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -244,12 +244,12 @@ export default function AdminProjectDetailModal({ pid, onClose, onUpdated, onDel
                 {/* 작성자 */}
                 <div>
                   <p className="text-xs text-muted-foreground mb-2">작성자</p>
-                  {project.author ? (
+                  {project.ownerId ? (
                     <div className="flex items-center gap-3">
-                      {project.author.avatarUrl ? (
+                      {project.ownerId.avatarUrl ? (
                         <Image
-                          src={project.author.avatarUrl}
-                          alt={project.author.nName}
+                          src={project.ownerId.avatarUrl}
+                          alt={project.ownerId.nName}
                           width={36}
                           height={36}
                           className="w-9 h-9 rounded-full object-cover border border-border"
@@ -257,19 +257,19 @@ export default function AdminProjectDetailModal({ pid, onClose, onUpdated, onDel
                         />
                       ) : (
                         <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center text-sm text-muted-foreground border border-border">
-                          {project.author.nName?.[0]?.toUpperCase() || '?'}
+                          {project.ownerId.nName?.[0]?.toUpperCase() || '?'}
                         </div>
                       )}
                       <div>
                         <p className="text-sm font-medium text-foreground">
-                          {project.author.nName}
+                          {project.ownerId.nName}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          {project.author.authorEmail}
+                          {project.ownerId.authorEmail}
                         </p>
                       </div>
                       <button
-                        onClick={() => setAuthorModalId(project.author!._id)}
+                        onClick={() => setAuthorModalId(project.ownerId!._id)}
                         className="ml-auto text-xs px-2 py-1 rounded bg-muted hover:bg-muted/70 text-muted-foreground transition-colors"
                       >
                         사용자 정보 보기


### PR DESCRIPTION
## 🚨 Hotfix

- **오류**: 대시보드에서 프로젝트 선택 시 `TypeError: Cannot read properties of undefined (reading '_id')` 발생, 홈으로 리다이렉트
- **원인**: Phase 1 스키마 변경(`author`→`ownerId`, `projectMembers`→`members`) 후 프론트엔드 코드가 구 필드명을 참조
- **수정**: 7개 파일에서 필드명을 신 스키마에 맞게 치환 + 기존 `any` 타입/ESLint 경고 정리

## 변경 파일
- `src/app/dashboard/[pid]/layout.tsx` — 접근 권한 체크 필드명
- `src/app/dashboard/[pid]/page.tsx` — 프로젝트 데이터 참조
- `src/app/dashboard/[pid]/wbs/page.tsx` — 멤버 목록 참조
- `src/app/projects/[pid]/manage/page.tsx` — 멤버 관리 참조
- `src/components/admin/AdminProjectDetailModal.tsx` — 관리자 모달 참조
- `src/app/api/kanban/boards/[boardId]/members/route.ts` — 멤버 API populate 경로
- `src/app/api/admin/projects/[pid]/route.ts` — 관리자 API populate 경로

## 검증

- [x] `npm run test:run` 653개 전체 통과
- [x] `npx tsc --noEmit` 통과
- [x] ESLint 경고 0개

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)