### PR TITLE
fix: MAP.md 자동 갱신 워크플로우를 PR 방식으로 전환

### DIFF
--- a/.github/workflows/update-maps.yml
+++ b/.github/workflows/update-maps.yml
@@ -12,6 +12,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -26,10 +27,30 @@ jobs:
       - name: MAP.md 갱신 실행
         run: node scripts/generate-maps.js
 
-      - name: 변경사항 커밋 & 푸시
+      - name: 변경사항 확인
+        id: check
         run: |
+          git add src/**/MAP.md
+          if git diff --staged --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: PR 생성
+        if: steps.check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="auto/update-maps-$(date +%Y%m%d-%H%M%S)"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add src/**/MAP.md
-          git diff --staged --quiet || git commit -m "docs: auto-update MAP.md files"
-          git push
+          git checkout -b "$BRANCH"
+          git commit -m "docs: auto-update MAP.md files"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "docs: auto-update MAP.md files" \
+            --body "MAP.md 파일 자동 갱신 (GitHub Actions)" \
+            --base main \
+            --head "$BRANCH"
+          gh pr merge "$BRANCH" --auto --squash --delete-branch


### PR DESCRIPTION
main 브랜치 보호 규칙으로 인해 직접 push가 거부되던 문제 해결.
변경사항이 있을 때만 브랜치 생성 → PR → auto-merge(squash) 방식으로 전환.

## 작업 요약

<!-- 이 PR에서 무엇을 했는지 한 줄로 설명해주세요 -->

## 변경된 파일 및 내용

## <!-- 주요 변경 파일과 변경 이유를 작성해주세요 -->

## 미완성 / 다음 세션에서 이어받을 부분

<!-- 이번 PR에서 완료하지 못한 부분이 있으면 작성해주세요 -->

없음

## 건드리면 안 되는 부분

<!-- 다른 팀원이 이 코드를 수정할 때 주의해야 할 부분이 있으면 작성해주세요 -->

없음

## 체크리스트

- [ ] `'use client'` 선언 확인 (클라이언트 컴포넌트)
- [ ] API Route에 `dynamic = 'force-dynamic'` + `dbConnect()` 호출 확인
- [ ] 응답 형식 `{ success, data | message | error }` 통일 확인
- [ ] `.workzones.yml` 업데이트 (작업 구역 변경 시)
- [ ] `npm run lint` 경고 확인

## 사용한 AI 모델

<!-- 바이브코딩 시 사용한 모델을 기록해주세요 -->

- [ ] Claude
- [ ] Gemini
- [ ] 직접 작성
