### PR TITLE
chore: work-log 및 문서 갱신 (feature/243-ai-execution-result)

### DIFF
--- a/.workzones.yml
+++ b/.workzones.yml
@@ -15,19 +15,4 @@
 #     reason: "실시간 소켓 로직 작업 중"
 #     expires: "2026-04-05"
 
-zones:
-  - path: 'src/app/api/ai/'
-    owner: 'kimis0719'
-    status: 'active'
-    reason: '#243 AI 지시서 실행결과 자동 완료처리'
-    expires: '2026-04-11'
-  - path: 'src/components/board/InstructionModal.tsx'
-    owner: 'kimis0719'
-    status: 'active'
-    reason: '#243 AI 지시서 실행결과 자동 완료처리'
-    expires: '2026-04-11'
-  - path: 'src/lib/models/kanban/NoteModel.ts'
-    owner: 'kimis0719'
-    status: 'active'
-    reason: '#243 AI 지시서 실행결과 자동 완료처리'
-    expires: '2026-04-11'
+zones: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@
 | 작업             | 읽을 파일                                        |
 | ---------------- | ------------------------------------------------ |
 | API 작업         | `src/app/api/MAP.md` → 해당 도메인 `MAP.md`      |
+| AI 기능 작업     | `src/app/api/ai/MAP.md`                          |
 | 칸반 작업        | `src/app/api/kanban/MAP.md` + `src/store/MAP.md` |
 | 프로젝트 작업    | `src/app/api/projects/MAP.md`                    |
 | 유저/프로필 작업 | `src/app/api/users/MAP.md`                       |
@@ -116,4 +117,4 @@ feature/* / fix/* /
 
 | 담당 영역                  | 작업자 | 상태    | 작업 내용 |
 | -------------------------- | ------ | ------- | --------- |
-| `src/app/api/ai/`, `src/components/board/` | kimis0719 | 🟡 작업 중 | #243 AI 지시서 실행결과 자동 완료처리 |
+| (현재 작업 중인 항목 없음) | —      | 🟢 자유 | —         |

--- a/src/app/api/MAP.md
+++ b/src/app/api/MAP.md
@@ -4,6 +4,7 @@
 
 | 도메인     | 경로                   | MAP.md                    |
 | ---------- | ---------------------- | ------------------------- |
+| AI         | `api/ai/`              | `api/ai/MAP.md`           |
 | 칸반       | `api/kanban/`          | `api/kanban/MAP.md`       |
 | 프로젝트   | `api/projects/`        | `api/projects/MAP.md`     |
 | 유저       | `api/users/`           | `api/users/MAP.md`        |

--- a/src/app/api/ai/MAP.md
+++ b/src/app/api/ai/MAP.md
@@ -1,0 +1,44 @@
+# AI API MAP
+
+## 엔드포인트
+
+| 메서드 | 경로 | 핸들러 파일 | 설명 |
+|--------|------|-------------|------|
+| POST | `/api/ai/generate-instruction` | `generate-instruction/route.ts` | AI 지시서 생성 (SSE 스트리밍) |
+| POST | `/api/ai/execution-result` | `execution-result/route.ts` | 실행결과 파싱 & 노트 자동 완료처리 |
+| GET | `/api/ai/history/[id]` | `history/[id]/route.ts` | 지시서 히스토리 단건 조회 |
+| GET/POST | `/api/ai/presets` | `presets/route.ts` | AI 프리셋 목록 조회 / 생성 |
+
+## 주요 유틸 (src/lib/utils/ai/)
+
+| 파일 | 역할 |
+|------|------|
+| `parseExecutionResult.ts` | spm-result 코드블록 or bare JSON 파싱 (CRLF, balanced bracket, 리터럴 줄바꿈 처리) |
+| `generateResultTemplate.ts` | 지시서에 삽입할 spm-result JSON 템플릿 생성 |
+| `buildAiContext.ts` | 보드 데이터 → systemPrompt + userMessage 조립 |
+
+## 관련 모델
+
+- `AiInstructionHistory` — 지시서 히스토리 (resultMarkdown에 spm-result 템플릿 포함)
+- `AiExecutionLog` — 실행결과 로그 (instructionId, results[], testsResult, parseMethod)
+- `AiSettings` — AI 설정 (provider, modelPriority, cooldown, dailyLimit)
+- `AiUsage` — 사용량 기록
+
+## 실행결과 처리 흐름
+
+```
+[Agent 실행] → spm-result JSON 복사
+→ "결과 보고" 버튼 클릭 (InstructionModal or HistoryModal)
+→ ExecutionResultModal (textarea 붙여넣기)
+→ POST /api/ai/execution-result
+→ parseExecutionResult() → done 노트 자동완료 / partial,failed → requiresConfirmation
+→ ExecutionResultConfirm UI
+→ boardStore.completeNote() 호출 (보드 상태 + socket 동기화)
+→ AiExecutionLog 저장
+```
+
+## 주의
+
+- `generate-instruction` 은 SSE 스트리밍(`Response` 반환)이므로 `withApiLogging` 래퍼 불가
+- `execution-result`는 `withApiLogging(handlePost, ...)` 패턴 사용
+- 지시서 resultMarkdown에는 spm-result 템플릿이 DB에만 저장됨 (스트리밍 미포함); 클라이언트는 `done` SSE 이후 `/api/ai/history/{id}` 재조회

--- a/src/lib/models/MAP.md
+++ b/src/lib/models/MAP.md
@@ -17,6 +17,7 @@
 | `AiUsage.ts`       | `aiusages`        | userId, projectId, provider, inputTokens        |
 | `AiPreset.ts`      | `aipresets`       | projectId, name, roleInstruction                |
 | `AiInstructionHistory.ts` | `aiinstructionhistories` | projectId, boardId, target, resultMarkdown |
+| `AiExecutionLog.ts`       | `aiexecutionlogs`        | instructionId, boardId, results[], testsResult, parseMethod |
 | `kanban/`          | —                 | Board, Section, Note                            |
 | `wbs/`             | —                 | WBS Task                                        |
 

--- a/src/store/MAP.md
+++ b/src/store/MAP.md
@@ -6,6 +6,7 @@
 | ~~`wbsStore.ts`~~ | ~~삭제됨 (Phase 7)~~ | — |
 | `modalStore.ts` | 전역 모달 상태      | openModal, closeModal                              |
 | `instructionStore.ts` | AI 지시서 모달/생성 | openModal, generate (SSE), setTarget, setPreset |
+| `executionResultStore.ts` | AI 실행결과 처리 모달 | open, close, submit (input→confirming 2단계) |
 | `applicationStore.ts` | 내 지원 상태 맵 | fetchMyApplications, addApplication, withdrawApplication, getStatus |
 
 ## 공통 패턴
@@ -32,5 +33,6 @@ export const useFooStore = create<FooState & FooActions>()(
 
 - `applicationStore.ts`
 - `boardStore.ts`
+- `executionResultStore.ts`
 - `instructionStore.ts`
 - `modalStore.ts`

--- a/work-logs/2026-04-04-kimis0719-cecbc57.md
+++ b/work-logs/2026-04-04-kimis0719-cecbc57.md
@@ -1,0 +1,47 @@
+## 2026-04-04 — kimis0719 (feature/243-ai-execution-result) `cecbc57`
+
+> 모델: claude-sonnet-4-6 (spm-done 자동생성)
+
+## 작업 요약
+
+AI 지시서 실행결과 자동 완료처리 기능 구현 — Agent가 결과를 spm-result JSON으로 보고하면 SPM이 자동으로 파싱하여 완료처리하고 실행 로그를 저장한다.
+
+## 변경된 파일
+
+- `src/types/ai-execution-result.ts` — AiExecutionResult, ExecutionNoteResult 타입 정의
+- `src/lib/models/AiExecutionLog.ts` — 실행로그 Mongoose 모델 신규 생성
+- `src/lib/utils/ai/parseExecutionResult.ts` — spm-result 파싱 엔진 (spm-result 코드블록 / bare JSON, CRLF 정규화, balanced bracket 추출, 리터럴 줄바꿈 sanitize)
+- `src/lib/utils/ai/parseExecutionResult.test.ts` — 파싱 엔진 테스트 (코드블록·직접 JSON·CRLF·리터럴 줄바꿈·유효성 검사 등)
+- `src/lib/utils/ai/generateResultTemplate.ts` — 지시서 하단에 삽입되는 spm-result 템플릿 생성 유틸
+- `src/app/api/ai/execution-result/route.ts` — POST /api/ai/execution-result: 파싱 → done 노트 자동 완료처리 → AiExecutionLog 저장
+- `src/app/api/ai/execution-result/route.test.ts` — API 엔드포인트 테스트 11개
+- `src/app/api/ai/generate-instruction/route.ts` — LLM 스트리밍 완료 후 실행결과 템플릿 자동 삽입 (DB에만 저장, 스트리밍 미포함)
+- `src/store/executionResultStore.ts` — 실행결과 모달 상태 관리 (input/confirming 2단계)
+- `src/store/instructionStore.ts` — done SSE 이벤트 후 DB에서 전체 마크다운(템플릿 포함) 재조회
+- `src/components/board/ExecutionResultModal.tsx` — 실행결과 붙여넣기 입력 모달
+- `src/components/board/ExecutionResultConfirm.tsx` — 자동 완료처리 결과 확인 UI (autoCompleted/requiresConfirmation 분리 표시)
+- `src/components/board/HistoryModal.tsx` — "결과 보고" 버튼 추가, 연관 노트 전부 완료 시 비활성화
+- `src/components/board/InstructionModal.tsx` — "결과 보고" 버튼 추가
+- `src/components/board/BoardShell.tsx` — ExecutionResultModal 마운트
+- `docs/plans/ai-features-plan-v2.md` — AI 기능 기획서 추가
+
+## 테스트 결과
+
+- 실행 명령: `npm run test:run`
+- 결과: 478 passed / 0 failed
+- 신규 추가 테스트: 22개
+  - `src/lib/utils/ai/parseExecutionResult.test.ts` (11개)
+  - `src/app/api/ai/execution-result/route.test.ts` (11개)
+- 미작성 테스트 및 사유: 없음
+
+## 건드리면 안 되는 부분
+
+| 파일 | 위치 | 이유 |
+|------|------|------|
+| `ExecutionResultConfirm.tsx` | `useEffect` (autoCompleted 순회) | mount 시 boardStore.completeNote() + socket 순서 의존. 실행 순서 바꾸면 보드 상태/실시간 동기화 깨짐 |
+| `parseExecutionResult.ts` | `sanitizeJsonLiteralNewlines`, `extractFirstJson` | 리터럴 줄바꿈·중첩 중괄호 처리 state machine. 실제 사용자 입력 패턴에 맞춰 튜닝됨 |
+| `generate-instruction/route.ts` | 스트리밍 완료 후 template 저장 → `done` SSE 이벤트 발행 순서 | 클라이언트가 hasResultTemplate 받고 /api/ai/history/{id} 재조회하는 흐름과 쌍으로 동작 |
+
+## 미완성 / 다음 세션에서 이어받을 부분
+
+없음


### PR DESCRIPTION
## Summary
- #243 AI 지시서 실행결과 자동 완료처리 작업 종료
- work-log 생성 (2026-04-04-kimis0719-cecbc57.md)
- `src/app/api/ai/MAP.md` 신규 생성
- `src/app/api/MAP.md`에 ai 도메인 추가
- `src/lib/models/MAP.md`에 AiExecutionLog 추가
- `src/store/MAP.md`에 executionResultStore 추가
- CLAUDE.md 현황 표 정리, .workzones.yml 해제

## Test plan
- [ ] 문서 변경만 포함 (코드 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)