### PR TITLE
fix: preview-deploy 문서 PR 경쟁 조건 방지

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'work-logs/**'
+      - 'docs/**'
+      - '**/*.md'
+      - '.workzones.yml'
+      - '.claude/**'
 
 jobs:
   deploy-preview:


### PR DESCRIPTION
## Summary
- `preview-deploy.yml`에 `paths-ignore` 추가
- work-log/문서 전용 PR이 `test-server` 브랜치를 force push로 덮어쓰는 경쟁 조건 해결
- Phase 6 배포 누락의 근본 원인 수정

## 원인 분석
`/spm-done`이 코드 PR과 문서 PR을 거의 동시에 생성 → 둘 다 `preview-deploy` 트리거 → 문서 PR이 Phase 6 코드 없이 `test-server`에 force push → Phase 6 배포 덮어씌워짐

## Test plan
- [ ] 문서 전용 PR 생성 시 `preview-deploy` 워크플로우가 트리거되지 않는지 확인
- [ ] 코드 PR 생성 시 `preview-deploy`가 정상 트리거되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)