### PR TITLE
feat: UI/UX 전면 개편 Phase 5.5 — 대시보드 위젯 신규 개발 (#274)

### DIFF
--- a/src/app/api/projects/[pid]/route.ts
+++ b/src/app/api/projects/[pid]/route.ts
@@ -211,7 +211,15 @@ async function handlePatch(request: Request, { params }: { params: { pid: string
     // 업데이트 객체 구성
     const updateData: Record<string, unknown> = {};
     if (status) updateData.status = status;
-    if (overview !== undefined) updateData.overview = overview; // 빈 문자열 허용
+    if (overview !== undefined) {
+      if (typeof overview === 'string' && overview.length > 4000) {
+        return NextResponse.json(
+          { success: false, message: '프로젝트 개요는 4000자 이내로 작성해주세요.' },
+          { status: 400 }
+        );
+      }
+      updateData.overview = overview; // 빈 문자열 허용
+    }
 
     if (Object.keys(updateData).length === 0) {
       return NextResponse.json(

--- a/src/app/dashboard/[pid]/layout.tsx
+++ b/src/app/dashboard/[pid]/layout.tsx
@@ -31,6 +31,7 @@ export default function DashboardLayout({
   const { data: session, status } = useSession();
 
   const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
+  const [isOwner, setIsOwner] = useState(false);
 
   // 권한 체크
   useEffect(() => {
@@ -70,6 +71,7 @@ export default function DashboardLayout({
 
           if (isAuthor || isMember) {
             setIsAuthorized(true);
+            setIsOwner(isAuthor);
           } else {
             setIsAuthorized(false);
             router.replace('/');
@@ -98,6 +100,9 @@ export default function DashboardLayout({
     { href: `/dashboard/${pid}`, icon: 'dashboard', label: '대시보드 홈' },
     { href: `/dashboard/${pid}/kanban`, icon: 'view_kanban', label: '칸반보드' },
     { href: `/projects/${pid}/manage`, icon: 'group', label: '멤버관리' },
+    ...(isOwner
+      ? [{ href: `/projects/${pid}/edit`, icon: 'settings', label: '프로젝트 설정' }]
+      : []),
   ];
 
   return (

--- a/src/app/dashboard/[pid]/page.tsx
+++ b/src/app/dashboard/[pid]/page.tsx
@@ -32,6 +32,8 @@ import ProjectHeader from '@/components/dashboard/ProjectHeader';
 import ResourceModal from '@/components/dashboard/ResourceModal';
 import ProjectOverview from '@/components/dashboard/ProjectOverview';
 import MemberWidget from '@/components/dashboard/MemberWidget';
+import SprintPulseWidget from '@/components/dashboard/SprintPulseWidget';
+import RecentChatWidget from '@/components/dashboard/RecentChatWidget';
 
 export default function DashboardPage({ params }: { params: { pid: string } }) {
   const { pid } = params;
@@ -278,44 +280,51 @@ export default function DashboardPage({ params }: { params: { pid: string } }) {
         categoryLabel=""
         isAuthor={isAuthor || false}
         onStatusChange={(newStatus) => handleUpdateProject({ status: newStatus })}
+        onTeamChat={handleTeamChat}
       />
 
       {/* 2. Bento Grid Layout */}
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-start">
-        {/* Project Overview — 8칸 */}
-        <div className="md:col-span-8">
-          <ProjectOverview
-            project={project as unknown as IProject}
-            isAuthor={isAuthor || false}
-            onUpdate={(newOverview) => handleUpdateProject({ overview: newOverview })}
-          />
+      <div className="space-y-6">
+        {/* Row 1: Overview + Member — 높이 동기화 */}
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-6 md:items-stretch">
+          <div className="md:col-span-8">
+            <ProjectOverview
+              project={project as unknown as IProject}
+              isAuthor={isAuthor || false}
+              onUpdate={(newOverview) => handleUpdateProject({ overview: newOverview })}
+            />
+          </div>
+          <div className="md:col-span-4">
+            {project && session?.user && (
+              <MemberWidget
+                members={(project.members || [])
+                  .filter((pm: PopulatedProjectMember) => pm.userId?._id)
+                  .map((pm: PopulatedProjectMember) => ({
+                    _id: pm.userId!._id,
+                    nName: pm.userId?.nName,
+                    email: pm.userId?.authorEmail,
+                    image: pm.userId?.avatarUrl,
+                    role: pm.role,
+                  }))}
+                currentUserId={session.user._id}
+                projectId={pid}
+              />
+            )}
+          </div>
         </div>
 
-        {/* Member Widget — 4칸 */}
-        <div className="md:col-span-4 space-y-6">
-          {/* 팀 채팅 진입 버튼 */}
-          <button
-            onClick={handleTeamChat}
-            className="w-full py-3 px-4 bg-primary-container text-on-primary font-bold rounded-xl hover:opacity-90 transition-all flex items-center justify-center gap-2"
-          >
-            <span className="material-symbols-outlined text-[20px]">chat_bubble</span>팀 채팅방 입장
-          </button>
-
-          {project && session?.user && (
-            <MemberWidget
-              members={(project.members || [])
-                .filter((pm: PopulatedProjectMember) => pm.userId?._id)
-                .map((pm: PopulatedProjectMember) => ({
-                  _id: pm.userId!._id,
-                  nName: pm.userId?.nName,
-                  email: pm.userId?.authorEmail,
-                  image: pm.userId?.avatarUrl,
-                  role: pm.role,
-                }))}
-              currentUserId={session.user._id}
-              projectId={pid}
+        {/* Row 2: Sprint Pulse + Recent Chat — 높이 동기화 */}
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-6 md:items-stretch">
+          <div className="md:col-span-6">
+            <SprintPulseWidget pid={pid} />
+          </div>
+          <div className="md:col-span-6">
+            <RecentChatWidget
+              projectId={(project as unknown as { _id: string })._id}
+              pid={pid}
+              currentUserId={session?.user?._id || ''}
             />
-          )}
+          </div>
         </div>
       </div>
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,16 +1,23 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import Link from 'next/link';
 
-const isTestEnv =
+const envTestFlag =
   process.env.NEXT_PUBLIC_APP_ENV === 'local' || process.env.NEXT_PUBLIC_APP_ENV === 'test';
 
 export default function LoginPage() {
   const [isSocialLoading, setIsSocialLoading] = useState<'github' | 'google' | null>(null);
   const [error, setError] = useState('');
+  const [isTestEnv, setIsTestEnv] = useState(envTestFlag);
+
+  useEffect(() => {
+    if (!envTestFlag && window.location.hostname === 'localhost') {
+      setIsTestEnv(true);
+    }
+  }, []);
   const router = useRouter();
 
   // 테스트 로그인 상태
@@ -35,10 +42,11 @@ export default function LoginPage() {
     setError('');
 
     try {
-      const result = await signIn('credentials', {
+      // 이메일 형식이면 그대로, 아니면 @test.com 붙이기
+      const email = testId.trim().includes('@') ? testId.trim() : `${testId.trim()}@test.com`;
+      const result = await signIn('test-login', {
         redirect: false,
-        authorEmail: `${testId.trim()}@test.com`,
-        password: '1234',
+        authorEmail: email,
       });
 
       if (result?.ok) {
@@ -233,20 +241,15 @@ export default function LoginPage() {
                   >
                     테스트 계정
                   </label>
-                  <div className="flex items-center gap-0">
-                    <input
-                      id="testId"
-                      type="text"
-                      required
-                      className="flex-1 px-5 py-3.5 bg-surface-container-low rounded-l-lg text-on-surface text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all border-none placeholder:text-outline/50"
-                      placeholder="admin"
-                      value={testId}
-                      onChange={(e) => setTestId(e.target.value)}
-                    />
-                    <span className="px-4 py-3.5 bg-surface-container-high rounded-r-lg text-on-surface-variant text-sm font-medium select-none">
-                      @test.com
-                    </span>
-                  </div>
+                  <input
+                    id="testId"
+                    type="text"
+                    required
+                    className="w-full px-5 py-3.5 bg-surface-container-low rounded-lg text-on-surface text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all border-none placeholder:text-outline/50"
+                    placeholder="admin 또는 user@example.com"
+                    value={testId}
+                    onChange={(e) => setTestId(e.target.value)}
+                  />
                 </div>
                 <button
                   type="submit"

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,16 +1,23 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import Link from 'next/link';
 
-const isTestEnv =
+const envTestFlag =
   process.env.NEXT_PUBLIC_APP_ENV === 'local' || process.env.NEXT_PUBLIC_APP_ENV === 'test';
 
 export default function RegisterPage() {
   const [isSocialLoading, setIsSocialLoading] = useState<'github' | 'google' | null>(null);
   const [error, setError] = useState('');
+  const [isTestEnv, setIsTestEnv] = useState(envTestFlag);
+
+  useEffect(() => {
+    if (!envTestFlag && window.location.hostname === 'localhost') {
+      setIsTestEnv(true);
+    }
+  }, []);
   const router = useRouter();
 
   // 테스트 회원가입 상태

--- a/src/components/dashboard/MemberWidget.tsx
+++ b/src/components/dashboard/MemberWidget.tsx
@@ -58,7 +58,7 @@ export default function MemberWidget({ members, currentUserId, projectId }: Memb
   }, [currentUserId]);
 
   return (
-    <div className="bg-surface-container-lowest rounded-xl shadow-[0_2px_8px_rgba(26,28,28,0.04)] p-6 md:p-8 h-full">
+    <div className="bg-surface-container-lowest rounded-xl shadow-[0_2px_8px_rgba(26,28,28,0.04)] p-6 md:p-8 h-full md:max-h-[400px] flex flex-col">
       <h3 className="font-semibold font-headline text-on-surface mb-6 flex items-center justify-between">
         팀원
         <span className="text-xs bg-surface-container-high px-2 py-0.5 rounded-full text-on-surface-variant">
@@ -66,7 +66,7 @@ export default function MemberWidget({ members, currentUserId, projectId }: Memb
         </span>
       </h3>
 
-      <ul className="space-y-4">
+      <ul className="space-y-4 flex-1 min-h-0 overflow-y-auto scrollbar-hide">
         {members.map((member) => {
           const isOnline = onlineUserIds.has(member._id) || member._id === currentUserId;
           const displayName =
@@ -109,7 +109,9 @@ export default function MemberWidget({ members, currentUserId, projectId }: Memb
       </ul>
 
       {members.length === 0 && (
-        <div className="text-sm text-on-surface-variant/50 py-4 text-center">팀원이 없습니다.</div>
+        <div className="flex-1 flex items-center justify-center text-sm text-on-surface-variant/50">
+          팀원이 없습니다.
+        </div>
       )}
     </div>
   );

--- a/src/components/dashboard/ProjectHeader.tsx
+++ b/src/components/dashboard/ProjectHeader.tsx
@@ -5,6 +5,7 @@ interface ProjectHeaderProps {
   categoryLabel?: string;
   isAuthor: boolean;
   onStatusChange: (newStatus: string) => Promise<void>;
+  onTeamChat?: () => void;
 }
 
 export default function ProjectHeader({
@@ -12,6 +13,7 @@ export default function ProjectHeader({
   categoryLabel,
   isAuthor,
   onStatusChange,
+  onTeamChat,
 }: ProjectHeaderProps) {
   // 상태 코드에 따른 라벨 및 스타일 매핑
   const getStatusInfo = (status: string) => {
@@ -77,8 +79,16 @@ export default function ProjectHeader({
         </h1>
       </div>
 
-      {/* 6단계에서 상태 변경 드롭다운 등 추가 예정 */}
-      <div className="flex items-center gap-2">{/* Placeholder for future action buttons */}</div>
+      <div className="flex items-center gap-2">
+        {onTeamChat && (
+          <button
+            onClick={onTeamChat}
+            className="py-2.5 px-5 bg-primary-container text-on-primary font-bold rounded-xl hover:opacity-90 transition-all flex items-center gap-2 text-sm"
+          >
+            <span className="material-symbols-outlined text-[20px]">chat_bubble</span>팀 채팅방 입장
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/dashboard/ProjectOverview.tsx
+++ b/src/components/dashboard/ProjectOverview.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from 'react';
 import { IProject } from '@/lib/models/Project';
 
+const MAX_LENGTH = 4000;
+
 interface ProjectOverviewProps {
   project: IProject;
   isAuthor: boolean;
@@ -37,9 +39,11 @@ export default function ProjectOverview({ project, isAuthor, onUpdate }: Project
     setIsEditing(false);
   };
 
+  const isOverLimit = overview.length > MAX_LENGTH;
+
   return (
-    <div className="bg-surface-container-lowest rounded-xl shadow-[0_2px_8px_rgba(26,28,28,0.04)] p-6 md:p-8">
-      <div className="flex justify-between items-center mb-4">
+    <div className="bg-surface-container-lowest rounded-xl shadow-[0_2px_8px_rgba(26,28,28,0.04)] p-6 md:p-8 h-full md:max-h-[400px] flex flex-col">
+      <div className="flex justify-between items-center mb-4 shrink-0">
         <h2 className="text-lg font-semibold font-headline text-on-surface">프로젝트 개요</h2>
         {isAuthor && !isEditing && (
           <button
@@ -52,40 +56,54 @@ export default function ProjectOverview({ project, isAuthor, onUpdate }: Project
       </div>
 
       {isEditing ? (
-        <div className="space-y-3">
+        <div className="space-y-3 flex-1 flex flex-col min-h-0">
           <textarea
             value={overview}
-            onChange={(e) => setOverview(e.target.value)}
-            className="w-full h-48 p-4 text-sm text-on-surface bg-surface-container-low border-none rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-container/20 resize-none"
+            onChange={(e) => setOverview(e.target.value.slice(0, MAX_LENGTH + 100))}
+            maxLength={MAX_LENGTH + 100}
+            className={`w-full min-h-[160px] max-h-[240px] p-4 text-sm text-on-surface bg-surface-container-low border-none rounded-xl focus:outline-none focus:ring-2 resize-none ${
+              isOverLimit ? 'focus:ring-error/30' : 'focus:ring-primary-container/20'
+            }`}
             placeholder="프로젝트의 목표, 마일스톤, 현재 상황 등을 자유롭게 작성해주세요."
           />
-          <div className="flex justify-end gap-2">
-            <button
-              onClick={handleCancel}
-              className="px-4 py-2 text-xs font-medium text-on-surface-variant hover:bg-surface-container-high rounded-lg transition-colors"
-              disabled={isLoading}
+          <div className="flex justify-between items-center shrink-0">
+            <span
+              className={`text-xs tabular-nums ${
+                isOverLimit ? 'text-error font-bold' : 'text-on-surface-variant/50'
+              }`}
             >
-              취소
-            </button>
-            <button
-              onClick={handleSave}
-              className="px-4 py-2 text-xs font-bold text-on-primary bg-primary-container hover:opacity-90 rounded-lg transition-colors disabled:opacity-50"
-              disabled={isLoading}
-            >
-              {isLoading ? '저장 중...' : '저장 완료'}
-            </button>
+              {overview.length.toLocaleString()} / {MAX_LENGTH.toLocaleString()}자
+            </span>
+            <div className="flex gap-2">
+              <button
+                onClick={handleCancel}
+                className="px-4 py-2 text-xs font-medium text-on-surface-variant hover:bg-surface-container-high rounded-lg transition-colors"
+                disabled={isLoading}
+              >
+                취소
+              </button>
+              <button
+                onClick={handleSave}
+                className="px-4 py-2 text-xs font-bold text-on-primary bg-primary-container hover:opacity-90 rounded-lg transition-colors disabled:opacity-50"
+                disabled={isLoading || isOverLimit}
+              >
+                {isLoading ? '저장 중...' : '저장 완료'}
+              </button>
+            </div>
           </div>
         </div>
       ) : (
-        <div className="max-w-none text-on-surface-variant whitespace-pre-wrap text-sm leading-relaxed break-all">
-          {project.overview ? (
-            project.overview
-          ) : (
-            <span className="text-on-surface-variant/50 italic">
-              작성된 개요가 없습니다.
-              {isAuthor && ' 우측 상단의 수정 버튼을 눌러 개요를 작성해보세요.'}
-            </span>
-          )}
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-hide">
+          <div className="max-w-none text-on-surface-variant whitespace-pre-wrap text-sm leading-relaxed break-all">
+            {project.overview ? (
+              project.overview
+            ) : (
+              <span className="text-on-surface-variant/50 italic">
+                작성된 개요가 없습니다.
+                {isAuthor && ' 우측 상단의 수정 버튼을 눌러 개요를 작성해보세요.'}
+              </span>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/dashboard/RecentChatWidget.test.ts
+++ b/src/components/dashboard/RecentChatWidget.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * RecentChatWidget 단위 테스트
+ *
+ * React 렌더링 없이 핵심 로직을 검증합니다.
+ * - 채팅방 필터링 로직 (TEAM + projectId 매칭)
+ * - 메시지 sender 헬퍼 함수
+ * - 시간 포맷팅 함수
+ */
+
+// --- 채팅방 필터링 ---
+
+interface ChatRoom {
+  _id: string;
+  category: string;
+  projectId?: string;
+}
+
+const findTeamRoom = (rooms: ChatRoom[], projectId: string): ChatRoom | undefined =>
+  rooms.find((room) => room.category === 'TEAM' && room.projectId === projectId);
+
+describe('RecentChatWidget — 채팅방 필터링', () => {
+  const rooms: ChatRoom[] = [
+    { _id: 'r1', category: 'TEAM', projectId: 'proj-a' },
+    { _id: 'r2', category: 'INQUIRY', projectId: 'proj-a' },
+    { _id: 'r3', category: 'TEAM', projectId: 'proj-b' },
+    { _id: 'r4', category: 'PERSONAL' },
+  ];
+
+  it('TEAM + projectId 매칭으로 정확한 방을 찾는다', () => {
+    const result = findTeamRoom(rooms, 'proj-a');
+    expect(result?._id).toBe('r1');
+  });
+
+  it('다른 projectId의 TEAM 방은 매칭되지 않는다', () => {
+    const result = findTeamRoom(rooms, 'proj-b');
+    expect(result?._id).toBe('r3');
+  });
+
+  it('TEAM이 아닌 카테고리는 매칭되지 않는다', () => {
+    const onlyInquiry: ChatRoom[] = [{ _id: 'r2', category: 'INQUIRY', projectId: 'proj-a' }];
+    expect(findTeamRoom(onlyInquiry, 'proj-a')).toBeUndefined();
+  });
+
+  it('매칭 방이 없으면 undefined를 반환한다', () => {
+    expect(findTeamRoom(rooms, 'proj-z')).toBeUndefined();
+  });
+
+  it('빈 배열이면 undefined를 반환한다', () => {
+    expect(findTeamRoom([], 'proj-a')).toBeUndefined();
+  });
+});
+
+// --- Sender 헬퍼 ---
+
+type Sender = { _id: string; nName?: string; avatarUrl?: string } | string;
+
+const getSenderId = (sender: Sender) => (typeof sender === 'string' ? sender : sender._id);
+const getSenderName = (sender: Sender) =>
+  typeof sender === 'string' ? '알 수 없음' : sender.nName || '알 수 없음';
+const getSenderAvatar = (sender: Sender) =>
+  typeof sender === 'string' ? null : sender.avatarUrl || null;
+
+describe('RecentChatWidget — sender 헬퍼', () => {
+  it('object sender에서 _id를 추출한다', () => {
+    expect(getSenderId({ _id: 'u1', nName: 'A' })).toBe('u1');
+  });
+
+  it('string sender는 그대로 반환한다', () => {
+    expect(getSenderId('u2')).toBe('u2');
+  });
+
+  it('object sender에서 nName을 추출한다', () => {
+    expect(getSenderName({ _id: 'u1', nName: '홍길동' })).toBe('홍길동');
+  });
+
+  it('nName이 없으면 "알 수 없음"', () => {
+    expect(getSenderName({ _id: 'u1' })).toBe('알 수 없음');
+  });
+
+  it('string sender면 "알 수 없음"', () => {
+    expect(getSenderName('u1')).toBe('알 수 없음');
+  });
+
+  it('avatarUrl이 있으면 반환', () => {
+    expect(getSenderAvatar({ _id: 'u1', avatarUrl: 'http://img' })).toBe('http://img');
+  });
+
+  it('avatarUrl이 없으면 null', () => {
+    expect(getSenderAvatar({ _id: 'u1' })).toBeNull();
+  });
+
+  it('string sender면 avatar null', () => {
+    expect(getSenderAvatar('u1')).toBeNull();
+  });
+});
+
+// --- 시간 포맷팅 ---
+
+const formatTime = (dateStr: string, now: Date = new Date()) => {
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return '방금';
+  if (diffMin < 60) return `${diffMin}분 전`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}시간 전`;
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffDay < 7) return `${diffDay}일 전`;
+  return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+};
+
+describe('RecentChatWidget — 시간 포맷팅', () => {
+  const now = new Date('2026-04-09T12:00:00Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('30초 전 → "방금"', () => {
+    expect(formatTime('2026-04-09T11:59:30Z', now)).toBe('방금');
+  });
+
+  it('5분 전 → "5분 전"', () => {
+    expect(formatTime('2026-04-09T11:55:00Z', now)).toBe('5분 전');
+  });
+
+  it('3시간 전 → "3시간 전"', () => {
+    expect(formatTime('2026-04-09T09:00:00Z', now)).toBe('3시간 전');
+  });
+
+  it('2일 전 → "2일 전"', () => {
+    expect(formatTime('2026-04-07T12:00:00Z', now)).toBe('2일 전');
+  });
+
+  it('8일 전 → 날짜 표시', () => {
+    const result = formatTime('2026-04-01T12:00:00Z', now);
+    // ko-KR short month + day: "4월 1일" 등
+    expect(result).toMatch(/4월/);
+  });
+});

--- a/src/components/dashboard/RecentChatWidget.tsx
+++ b/src/components/dashboard/RecentChatWidget.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface ChatRoom {
+  _id: string;
+  category: string;
+  projectId?: string;
+  participants: { _id: string; nName?: string; avatarUrl?: string }[];
+}
+
+interface ChatMessage {
+  _id: string;
+  sender: { _id: string; nName?: string; avatarUrl?: string } | string;
+  content: string;
+  createdAt: string;
+}
+
+interface RecentChatWidgetProps {
+  projectId: string;
+  pid: string;
+  currentUserId: string;
+}
+
+export default function RecentChatWidget({ projectId, pid, currentUserId }: RecentChatWidgetProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [roomId, setRoomId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEmpty, setIsEmpty] = useState(false);
+
+  useEffect(() => {
+    if (!projectId) return;
+
+    const fetchRecentChat = async () => {
+      try {
+        setIsLoading(true);
+
+        // 1. 내 채팅방 목록에서 TEAM + projectId 매칭
+        const roomsRes = await fetch('/api/chat/rooms');
+        const roomsData = await roomsRes.json();
+        if (!roomsData.success) {
+          setIsEmpty(true);
+          return;
+        }
+
+        const teamRoom = roomsData.data.find(
+          (room: ChatRoom) => room.category === 'TEAM' && room.projectId === projectId
+        );
+
+        if (!teamRoom) {
+          setIsEmpty(true);
+          return;
+        }
+
+        setRoomId(teamRoom._id);
+
+        // 2. 최근 메시지 3개 조회
+        const msgRes = await fetch(`/api/chat/messages/${teamRoom._id}?limit=3`);
+        const msgData = await msgRes.json();
+
+        if (!msgData.success || !msgData.data || msgData.data.length === 0) {
+          setIsEmpty(true);
+          return;
+        }
+
+        setMessages(msgData.data);
+      } catch (err) {
+        console.error('[RecentChat] 에러:', err);
+        setIsEmpty(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRecentChat();
+  }, [projectId]);
+
+  const getSenderId = (sender: ChatMessage['sender']) =>
+    typeof sender === 'string' ? sender : sender._id;
+  const getSenderName = (sender: ChatMessage['sender']) =>
+    typeof sender === 'string' ? '알 수 없음' : sender.nName || '알 수 없음';
+  const getSenderAvatar = (sender: ChatMessage['sender']) =>
+    typeof sender === 'string' ? null : sender.avatarUrl || null;
+
+  const formatTime = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+    if (diffMin < 1) return '방금';
+    if (diffMin < 60) return `${diffMin}분 전`;
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return `${diffHour}시간 전`;
+    const diffDay = Math.floor(diffHour / 24);
+    if (diffDay < 7) return `${diffDay}일 전`;
+    return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+  };
+
+  // 로딩 스켈레톤
+  if (isLoading) {
+    return (
+      <div className="bg-surface-container-lowest rounded-xl shadow-[0_2px_8px_rgba(26,28,28,0.04)] p-6 md:p-8 h-full md:min-h-[320px]">
+        <div className="flex justify-between items-center mb-6">
+          <div className="h-5 w-28 bg-surface-container-low rounded animate-pulse" />
+          <div className="h-4 w-20 bg-surface-container-low rounded animate-pulse" />
+        </div>
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex gap-2">
+              <div className="w-7 h-7 bg-surface-container-low rounded-full animate-pulse shrink-0" />
+              <div className="flex-1 space-y-1">
+                <div className="h-3 w-16 bg-surface-container-low rounded animate-pulse" />
+                <div className="h-4 w-3/4 bg-surface-container-low rounded animate-pulse" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface-container-lowest rounded-xl shadow-[0_2px_8px_rgba(26,28,28,0.04)] p-6 md:p-8 h-full md:min-h-[320px] flex flex-col">
+      {/* Header */}
+      <div className="flex justify-between items-center mb-6">
+        <h3 className="text-base font-bold font-headline text-on-surface flex items-center gap-2">
+          <span className="material-symbols-outlined text-[20px] text-primary">forum</span>
+          Recent Chat
+        </h3>
+        {roomId && (
+          <Link
+            href={`/chat?roomId=${roomId}`}
+            className="text-xs text-primary font-semibold hover:underline flex items-center gap-0.5"
+          >
+            채팅 열기
+            <span className="material-symbols-outlined text-[16px]">arrow_forward</span>
+          </Link>
+        )}
+      </div>
+
+      {isEmpty ? (
+        <div className="flex-1 flex flex-col items-center justify-center">
+          <span className="material-symbols-outlined text-[40px] text-on-surface-variant/30 mb-2">
+            chat_bubble_outline
+          </span>
+          <p className="text-sm text-on-surface-variant/60">아직 팀 채팅 기록이 없습니다</p>
+        </div>
+      ) : (
+        <div className="space-y-3 flex-1 min-h-0 overflow-y-auto scrollbar-hide">
+          {messages.map((msg) => {
+            const isMine = getSenderId(msg.sender) === currentUserId;
+            const avatar = getSenderAvatar(msg.sender);
+
+            return (
+              <div
+                key={msg._id}
+                className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'}`}
+              >
+                {/* 아바타 */}
+                <div className="w-7 h-7 rounded-full bg-surface-container-low shrink-0 overflow-hidden flex items-center justify-center">
+                  {avatar ? (
+                    <Image
+                      src={avatar}
+                      alt=""
+                      width={28}
+                      height={28}
+                      className="w-full h-full object-cover"
+                      unoptimized
+                    />
+                  ) : (
+                    <span className="material-symbols-outlined text-[16px] text-on-surface-variant/50">
+                      person
+                    </span>
+                  )}
+                </div>
+
+                {/* 메시지 버블 */}
+                <div className={`max-w-[75%] ${isMine ? 'items-end' : 'items-start'}`}>
+                  {!isMine && (
+                    <p className="text-[10px] text-on-surface-variant/60 mb-0.5 px-1">
+                      {getSenderName(msg.sender)}
+                    </p>
+                  )}
+                  <div
+                    className={`px-3 py-2 rounded-xl text-sm break-words ${
+                      isMine
+                        ? 'bg-primary-container text-on-primary-container rounded-tr-sm'
+                        : 'bg-surface-container-low text-on-surface rounded-tl-sm'
+                    }`}
+                  >
+                    {msg.content}
+                  </div>
+                  <p
+                    className={`text-[10px] text-on-surface-variant/40 mt-0.5 px-1 ${
+                      isMine ? 'text-right' : 'text-left'
+                    }`}
+                  >
+                    {formatTime(msg.createdAt)}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/SprintPulseWidget.test.ts
+++ b/src/components/dashboard/SprintPulseWidget.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * SprintPulseWidget 단위 테스트
+ *
+ * React 렌더링 없이 Sprint Pulse 핵심 로직을 검증합니다.
+ * - 노트 분류 로직 (sectionId 유무로 할 일/진행 중 판별)
+ * - 진행률 계산 로직
+ */
+
+interface NoteItem {
+  _id: string;
+  sectionId?: string | null;
+}
+
+/** 노트 분류 순수 함수 (SprintPulseWidget 내부 로직과 동일) */
+const classifyNotes = (activeNotes: NoteItem[], doneNotes: NoteItem[]) => {
+  const todo = activeNotes.filter((n) => !n.sectionId).length;
+  const inProgress = activeNotes.filter((n) => !!n.sectionId).length;
+  const done = doneNotes.length;
+  const total = todo + inProgress + done;
+  return { todo, inProgress, done, total };
+};
+
+/** 진행률 계산 순수 함수 */
+const getPercent = (count: number, total: number): number => {
+  if (total === 0) return 0;
+  return Math.round((count / total) * 100);
+};
+
+describe('SprintPulseWidget — 노트 분류 로직', () => {
+  it('sectionId가 없는 active 노트는 "할 일"로 분류된다', () => {
+    const activeNotes: NoteItem[] = [
+      { _id: '1', sectionId: null },
+      { _id: '2', sectionId: undefined },
+      { _id: '3' },
+    ];
+    const result = classifyNotes(activeNotes, []);
+    expect(result.todo).toBe(3);
+    expect(result.inProgress).toBe(0);
+  });
+
+  it('sectionId가 있는 active 노트는 "진행 중"으로 분류된다', () => {
+    const activeNotes: NoteItem[] = [
+      { _id: '1', sectionId: 'sec1' },
+      { _id: '2', sectionId: 'sec2' },
+    ];
+    const result = classifyNotes(activeNotes, []);
+    expect(result.inProgress).toBe(2);
+    expect(result.todo).toBe(0);
+  });
+
+  it('done 노트는 "완료"로 분류된다', () => {
+    const doneNotes: NoteItem[] = [{ _id: '1' }, { _id: '2' }, { _id: '3' }];
+    const result = classifyNotes([], doneNotes);
+    expect(result.done).toBe(3);
+    expect(result.total).toBe(3);
+  });
+
+  it('혼합 시나리오: 할 일 2, 진행 중 3, 완료 5', () => {
+    const activeNotes: NoteItem[] = [
+      { _id: '1' },
+      { _id: '2', sectionId: null },
+      { _id: '3', sectionId: 'sec1' },
+      { _id: '4', sectionId: 'sec1' },
+      { _id: '5', sectionId: 'sec2' },
+    ];
+    const doneNotes: NoteItem[] = [
+      { _id: '6' },
+      { _id: '7' },
+      { _id: '8' },
+      { _id: '9' },
+      { _id: '10' },
+    ];
+    const result = classifyNotes(activeNotes, doneNotes);
+    expect(result.todo).toBe(2);
+    expect(result.inProgress).toBe(3);
+    expect(result.done).toBe(5);
+    expect(result.total).toBe(10);
+  });
+
+  it('노트가 없으면 모두 0이다', () => {
+    const result = classifyNotes([], []);
+    expect(result.todo).toBe(0);
+    expect(result.inProgress).toBe(0);
+    expect(result.done).toBe(0);
+    expect(result.total).toBe(0);
+  });
+});
+
+describe('SprintPulseWidget — 진행률 계산', () => {
+  it('전체 10개 중 3개면 30%', () => {
+    expect(getPercent(3, 10)).toBe(30);
+  });
+
+  it('전체 0이면 0%', () => {
+    expect(getPercent(0, 0)).toBe(0);
+  });
+
+  it('전체 3개 중 1개면 33% (반올림)', () => {
+    expect(getPercent(1, 3)).toBe(33);
+  });
+
+  it('전체와 같으면 100%', () => {
+    expect(getPercent(5, 5)).toBe(100);
+  });
+
+  it('전체 7개 중 2개면 29% (반올림)', () => {
+    expect(getPercent(2, 7)).toBe(29);
+  });
+});

--- a/src/components/dashboard/SprintPulseWidget.tsx
+++ b/src/components/dashboard/SprintPulseWidget.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+interface NoteItem {
+  _id: string;
+  sectionId?: string | null;
+}
+
+interface SprintPulseWidgetProps {
+  pid: string;
+}
+
+interface PulseData {
+  todo: number;
+  inProgress: number;
+  done: number;
+  total: number;
+}
+
+// --- 도넛 차트 SVG ---
+function DonutChart({ todo, inProgress, done, total }: PulseData) {
+  const size = 120;
+  const strokeWidth = 14;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+
+  if (total === 0) {
+    return (
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          className="text-surface-container-low"
+        />
+        <text
+          x="50%"
+          y="50%"
+          textAnchor="middle"
+          dominantBaseline="central"
+          className="fill-on-surface-variant/50 text-xs"
+        >
+          0
+        </text>
+      </svg>
+    );
+  }
+
+  const donePercent = done / total;
+  const inProgressPercent = inProgress / total;
+  const todoPercent = todo / total;
+
+  // 각 세그먼트의 offset (12시 방향 시작 = -90도 회전)
+  const doneOffset = 0;
+  const inProgressOffset = donePercent * circumference;
+  const todoOffset = (donePercent + inProgressPercent) * circumference;
+
+  const segments = [
+    { percent: donePercent, offset: doneOffset, color: '#34d399' }, // emerald-400
+    { percent: inProgressPercent, offset: inProgressOffset, color: '#fbbf24' }, // amber-400
+    { percent: todoPercent, offset: todoOffset, color: '#93b4f1' }, // primary-container 근사
+  ];
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="shrink-0">
+      {/* 배경 트랙 */}
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        className="text-surface-container-low"
+      />
+      {/* 세그먼트들 */}
+      {segments.map(
+        (seg, i) =>
+          seg.percent > 0 && (
+            <circle
+              key={i}
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              fill="none"
+              stroke={seg.color}
+              strokeWidth={strokeWidth}
+              strokeLinecap="butt"
+              strokeDasharray={`${seg.percent * circumference} ${circumference}`}
+              strokeDashoffset={-seg.offset}
+              transform={`rotate(-90 ${size / 2} ${size / 2})`}
+              className="transition-all duration-500"
+            />
+          )
+      )}
+      {/* 중앙 텍스트 */}
+      <text
+        x="50%"
+        y="44%"
+        textAnchor="middle"
+        dominantBaseline="central"
+        className="fill-on-surface text-2xl font-bold"
+        style={{ fontSize: '24px', fontWeight: 700 }}
+      >
+        {total}
+      </text>
+      <text
+        x="50%"
+        y="62%"
+        textAnchor="middle"
+        dominantBaseline="central"
+        className="fill-on-surface-variant/60"
+        style={{ fontSize: '10px' }}
+      >
+        총 노트
+      </text>
+    </svg>
+  );
+}
+
+export default function SprintPulseWidget({ pid }: SprintPulseWidgetProps) {
+  const [pulse, setPulse] = useState<PulseData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!pid) return;
+
+    const fetchPulse = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const boardRes = await fetch(`/api/kanban/boards?pid=${pid}`);
+        const boardData = await boardRes.json();
+        if (!boardData.success) throw new Error(boardData.message);
+        const boardId = boardData.data._id;
+
+        const [activeRes, doneRes] = await Promise.all([
+          fetch(`/api/kanban/notes?boardId=${boardId}&status=active`),
+          fetch(`/api/kanban/notes?boardId=${boardId}&status=done`),
+        ]);
+        const [activeData, doneData] = await Promise.all([activeRes.json(), doneRes.json()]);
+
+        if (!activeData.success || !doneData.success) {
+          throw new Error('노트 데이터를 불러올 수 없습니다.');
+        }
+
+        const activeNotes: NoteItem[] = activeData.data;
+        const doneNotes: NoteItem[] = doneData.data;
+
+        const todo = activeNotes.filter((n) => !n.sectionId).length;
+        const inProgress = activeNotes.filter((n) => !!n.sectionId).length;
+        const done = doneNotes.length;
+
+        setPulse({ todo, inProgress, done, total: todo + inProgress + done });
+      } catch (err) {
+        console.error('[SprintPulse] 에러:', err);
+        setError(err instanceof Error ? err.message : '데이터를 불러올 수 없습니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchPulse();
+  }, [pid]);
+
+  const getPercent = (count: number) => {
+    if (!pulse || pulse.total === 0) return 0;
+    return Math.round((count / pulse.total) * 100);
+  };
+
+  // 로딩 스켈레톤
+  if (isLoading) {
+    return (
+      <div className="bg-surface-container-lowest rounded-xl shadow-[0_2px_8px_rgba(26,28,28,0.04)] p-6 md:p-8 h-full md:min-h-[320px] flex flex-col">
+        <div className="flex justify-between items-center mb-6">
+          <div className="h-5 w-28 bg-surface-container-low rounded animate-pulse" />
+          <div className="h-4 w-24 bg-surface-container-low rounded animate-pulse" />
+        </div>
+        <div className="flex-1 flex flex-col sm:flex-row gap-6 items-center">
+          <div className="w-[120px] h-[120px] bg-surface-container-low rounded-full animate-pulse shrink-0" />
+          <div className="flex-1 w-full space-y-5">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="space-y-2">
+                <div className="h-4 w-20 bg-surface-container-low rounded animate-pulse" />
+                <div className="h-1.5 bg-surface-container-low rounded-full animate-pulse" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 에러
+  if (error) {
+    return (
+      <div className="bg-surface-container-lowest rounded-xl shadow-[0_2px_8px_rgba(26,28,28,0.04)] p-6 md:p-8 h-full md:min-h-[320px] flex flex-col">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="material-symbols-outlined text-[20px] text-error">error</span>
+          <h3 className="text-base font-bold font-headline text-on-surface">Sprint Pulse</h3>
+        </div>
+        <p className="text-sm text-on-surface-variant">{error}</p>
+      </div>
+    );
+  }
+
+  const isEmpty = !pulse || pulse.total === 0;
+
+  const bars = [
+    {
+      label: '할 일',
+      count: pulse?.todo ?? 0,
+      color: 'bg-[#93b4f1]',
+      track: 'bg-[#93b4f1]/20',
+      dot: 'bg-[#93b4f1]',
+    },
+    {
+      label: '진행 중',
+      count: pulse?.inProgress ?? 0,
+      color: 'bg-amber-400',
+      track: 'bg-amber-400/20',
+      dot: 'bg-amber-400',
+    },
+    {
+      label: '완료',
+      count: pulse?.done ?? 0,
+      color: 'bg-emerald-400',
+      track: 'bg-emerald-400/20',
+      dot: 'bg-emerald-400',
+    },
+  ];
+
+  const donePercent = getPercent(pulse?.done ?? 0);
+
+  return (
+    <div className="bg-surface-container-lowest rounded-xl shadow-[0_2px_8px_rgba(26,28,28,0.04)] p-6 md:p-8 h-full md:min-h-[320px] flex flex-col">
+      {/* Header */}
+      <div className="flex justify-between items-center mb-6 shrink-0">
+        <h3 className="text-base font-bold font-headline text-on-surface flex items-center gap-2">
+          <span className="material-symbols-outlined text-[20px] text-primary">sprint</span>
+          Sprint Pulse
+        </h3>
+        <Link
+          href={`/dashboard/${pid}/kanban`}
+          className="text-xs text-primary font-semibold hover:underline flex items-center gap-0.5"
+        >
+          칸반 보드 보기
+          <span className="material-symbols-outlined text-[16px]">arrow_forward</span>
+        </Link>
+      </div>
+
+      {isEmpty ? (
+        <div className="flex-1 flex flex-col items-center justify-center">
+          <span className="material-symbols-outlined text-[40px] text-on-surface-variant/30 mb-2">
+            task_alt
+          </span>
+          <p className="text-sm text-on-surface-variant/60">아직 노트가 없습니다</p>
+        </div>
+      ) : (
+        <div className="flex-1 flex flex-col sm:flex-row gap-6 items-center">
+          {/* 좌측(모바일: 상단) — 도넛 차트 */}
+          <div className="flex flex-col items-center gap-2 shrink-0">
+            <DonutChart
+              todo={pulse?.todo ?? 0}
+              inProgress={pulse?.inProgress ?? 0}
+              done={pulse?.done ?? 0}
+              total={pulse?.total ?? 0}
+            />
+            <p className="text-xs text-on-surface-variant/60">
+              완료율 <span className="font-bold text-on-surface">{donePercent}%</span>
+            </p>
+          </div>
+
+          {/* 우측(모바일: 하단) — 프로그레스 바 */}
+          <div className="flex-1 w-full space-y-4">
+            {bars.map((bar) => {
+              const percent = getPercent(bar.count);
+              return (
+                <div key={bar.label}>
+                  <div className="flex justify-between items-center mb-1.5">
+                    <span className="text-sm text-on-surface-variant font-medium flex items-center gap-1.5">
+                      <span className={`inline-block w-2 h-2 rounded-full ${bar.dot}`} />
+                      {bar.label}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-bold text-on-surface tabular-nums">
+                        {bar.count}
+                      </span>
+                      <span className="text-xs text-on-surface-variant/60 tabular-nums w-9 text-right">
+                        {percent}%
+                      </span>
+                    </div>
+                  </div>
+                  <div className={`h-1.5 rounded-full ${bar.track}`}>
+                    <div
+                      className={`h-full rounded-full ${bar.color} transition-all duration-500`}
+                      style={{ width: `${percent}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -48,6 +48,43 @@ export const authOptions: NextAuthOptions = {
         }
       },
     }),
+    // 테스트 전용: 비밀번호 없이 이메일만으로 로그인 (local/test 환경 전용)
+    CredentialsProvider({
+      id: 'test-login',
+      name: 'TestLogin',
+      credentials: {
+        authorEmail: { label: 'Email', type: 'text' },
+      },
+      async authorize(credentials: Record<'authorEmail', string> | undefined) {
+        const appEnv = process.env.NEXT_PUBLIC_APP_ENV;
+        if (appEnv !== 'local' && appEnv !== 'test' && process.env.NODE_ENV !== 'development') {
+          throw new Error('테스트 로그인은 개발/테스트 환경에서만 사용할 수 있습니다.');
+        }
+
+        if (!credentials?.authorEmail) {
+          throw new Error('이메일을 입력해주세요.');
+        }
+
+        await dbConnect();
+        const user = await User.findOne({ authorEmail: credentials.authorEmail });
+
+        if (!user) {
+          throw new Error('존재하지 않는 계정입니다.');
+        }
+        if (user.delYn === true) {
+          throw new Error('비활성화된 계정입니다. 관리자에게 문의하세요.');
+        }
+
+        return {
+          id: user._id.toString(),
+          _id: user._id.toString(),
+          email: user.authorEmail,
+          name: user.nName,
+          image: user.avatarUrl,
+          memberType: user.memberType,
+        };
+      },
+    }),
   ],
   session: {
     strategy: 'jwt',

--- a/src/lib/models/Project.ts
+++ b/src/lib/models/Project.ts
@@ -88,7 +88,7 @@ const ProjectSchema: Schema = new Schema(
       default: 'recruiting',
     },
     delYn: { type: Boolean, default: false },
-    overview: { type: String },
+    overview: { type: String, maxlength: 4000 },
     resources: [
       {
         type: {


### PR DESCRIPTION
## Summary
- SprintPulseWidget: 칸반 노트 상태별 카운트 + 프로그레스 바 + SVG 도넛 차트
- RecentChatWidget: 팀 채팅 최근 3개 메시지 읽기 전용 프리뷰
- 대시보드 Bento Grid 행 분리 (1행 8:4 + 2행 6:6), items-stretch 높이 동기화
- 팀 채팅 버튼 → ProjectHeader 우측 이동
- 프로젝트 개요 4000자 제한 (모델 + API + UI)
- 사이드바 프로젝트 설정 메뉴 (owner 전용)
- 테스트 로그인: localhost 자동 감지 + 비밀번호 없이 로그인 (test-login provider)

## Test plan
- [x] `npm run test:run` — 549 passed / 0 failed
- [x] `tsc --noEmit` — 타입 에러 없음
- [ ] 로컬 브라우저: 대시보드 카드 4개 높이 정렬 + 도넛 차트 + 채팅 미리보기
- [ ] 로컬 브라우저: 로그인 페이지 테스트 계정 버튼 확인
- [ ] 모바일 반응형 확인 (Sprint Pulse 상하 배치)

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)