### PR TITLE
feat: SPM 스킬 명명규칙을 Linear 연동으로 전환 (SPM-5)

### DIFF
--- a/.claude/skills/spm-commit/SKILL.md
+++ b/.claude/skills/spm-commit/SKILL.md
@@ -22,9 +22,13 @@ description: >
 ## 1단계: 변경 내용 수집
 
 ```bash
-git diff HEAD --name-only   # 변경된 파일 목록
-git diff HEAD               # 전체 diff 내용
+git rev-parse --abbrev-ref HEAD  # 현재 브랜치명 → SPM-[번호] 추출
+git diff HEAD --name-only        # 변경된 파일 목록
+git diff HEAD                    # 전체 diff 내용
 ```
+
+현재 브랜치명에서 `SPM-[숫자]` 패턴을 추출합니다 (예: `feature/SPM-42-kanban-improve` → `SPM-42`).
+Linear 이슈 ID를 커밋 메시지에 포함하기 위해 사용합니다.
 
 변경된 파일이 없으면 커밋할 내용이 없다고 안내하고 종료합니다.
 
@@ -93,10 +97,11 @@ npx tsc --noEmit
 
 ## 5단계: 커밋 메시지 초안 작성
 
-변경 내용을 분석해 아래 형식으로 커밋 메시지 초안을 작성합니다:
+변경 내용을 분석해 아래 형식으로 커밋 메시지 초안을 작성합니다.
+1단계에서 추출한 Linear 이슈 ID(`SPM-[번호]`)를 제목 끝에 포함합니다:
 
 ```
-feat: 섹션 중첩 캡처 로직 추가 및 zIndex 3단 계층 재설계
+feat: 섹션 중첩 캡처 로직 추가 및 zIndex 3단 계층 재설계 (SPM-42)
 
 - SectionModel에 parentSectionId, depth 필드 추가
 - 부모 섹션 드래그 시 자식 섹션 동시 이동
@@ -123,7 +128,7 @@ feat: 섹션 중첩 캡처 로직 추가 및 zIndex 3단 계층 재설계
 
 ```
 preview 예시:
-feat: 섹션 중첩 캡처 로직 추가
+feat: 섹션 중첩 캡처 로직 추가 (SPM-42)
 
 - SectionModel에 parentSectionId, depth 필드 추가
 - BoardShell zIndex 계산 로직 개선

--- a/.claude/skills/spm-done/SKILL.md
+++ b/.claude/skills/spm-done/SKILL.md
@@ -187,14 +187,16 @@ git diff origin/main...HEAD --stat        # 변경 통계
 현재 feature 브랜치에서 **코드 변경분만** 커밋하고 푸시합니다.
 work-log, CLAUDE.md, MAP.md 등 문서 변경은 이 커밋에 **포함하지 않습니다**.
 
+현재 브랜치와 연결된 Linear 이슈 ID를 브랜치명에서 추출합니다 (예: `feature/SPM-42-kanban-improve` → `SPM-42`).
+
 ```bash
 git add [코드 변경 파일만]
-git commit -m "[커밋 메시지]"
+git commit -m "[type]: [메시지] (SPM-[번호])"
 git push
 ```
 
 이어서 코드 PR을 생성합니다.
-현재 브랜치와 연결된 이슈 번호를 브랜치명에서 추출합니다 (예: `feature/180-spm-improve` → `#180`).
+PR 제목에 `(SPM-[번호])`를, PR 본문 마지막에 `Linear: SPM-[번호]`를 포함하여 Linear ↔ GitHub 자동 연동을 활성화합니다.
 
 `AskUserQuestion` 도구로 PR 초안 확인을 요청합니다:
 

--- a/.claude/skills/spm-hotfix/skill.md
+++ b/.claude/skills/spm-hotfix/skill.md
@@ -2,15 +2,15 @@
 name: spm-hotfix
 description: >
   Side Project Mate 긴급수정 커맨드.
-  `/spm-hotfix [오류 설명]` 형태로 호출하면 main 브랜치에서 즉시 수정 후
-  이슈 생성 → 브랜치 → 수정 → 테스트 → PR → 머지까지 전자동으로 수행합니다.
+  `/spm-hotfix [SPM-번호] [오류 설명]` 형태로 호출하면 main 브랜치에서 즉시 수정 후
+  브랜치 → 수정 → 테스트 → PR → 머지까지 전자동으로 수행합니다.
   운영 크리티컬 오류가 발생하여 즉시 배포가 필요한 경우에만 사용하세요.
   일반 버그 수정은 `/spm-start`를 사용하세요.
 ---
 
 # spm-hotfix — 긴급수정 커맨드
 
-이 스킬은 `/spm-hotfix [오류 설명]` 형태로 호출됩니다.
+이 스킬은 `/spm-hotfix [SPM-번호] [오류 설명]` 형태로 호출됩니다.
 
 > **사용 조건**: 운영 서버에서 크리티컬 오류가 발생하여 **즉시 배포**가 필요한 경우에만 사용합니다.
 > 일반 버그 수정은 `/spm-start`로 시작하세요.
@@ -18,6 +18,10 @@ description: >
 > **핵심 차이**: `/spm-start` + `/spm-done` 플로우와 달리,
 > 이 스킬은 PR 생성 후 **자동 머지**까지 수행하고 main으로 복귀합니다.
 > work-log 생성, MAP.md 갱신 등 문서 작업도 최소화하여 속도에 집중합니다.
+
+> **이슈 관리**: 이슈는 **Linear**에서 관리합니다 (팀 식별자: `SPM`).
+> 긴급 상황이라도 Linear에서 이슈를 먼저 생성하거나, 이슈 ID를 입력해주세요.
+> 정말 급한 경우 이슈 없이 진행할 수 있지만, 완료 후 반드시 Linear에서 이슈를 생성해주세요.
 
 ---
 
@@ -76,33 +80,40 @@ git status --porcelain
 
 ---
 
-## 1단계: 오류 분석 및 이슈 생성
+## 1단계: 오류 분석 및 Linear 이슈 확인
 
-인자로 받은 오류 설명을 분석합니다. 인자가 없으면 `AskUserQuestion`으로 오류 내용을 입력받습니다.
+### Linear 이슈 ID 확인
+
+인자에서 `SPM-[숫자]` 패턴을 추출합니다.
+인자가 없거나 이슈 ID가 없으면 `AskUserQuestion`으로 확인합니다:
+
+- question: "Linear 이슈 ID를 입력해주세요. 아직 없으면 '없음'을 선택하세요."
+- header: "Linear 이슈"
+- options:
+  - label: "이슈 ID 입력 (Recommended)", description: "Other를 선택해 SPM-번호를 입력하세요 (예: SPM-42)"
+  - label: "없음 — 이슈 없이 진행", description: "hotfix 완료 후 Linear에서 반드시 이슈를 생성해주세요"
+
+### 오류 설명 확인
+
+인자에서 이슈 ID를 제외한 텍스트를 오류 설명으로 사용합니다.
+없으면 `AskUserQuestion`으로 오류 내용을 입력받습니다:
 
 - question: "운영에서 발생한 오류를 설명해주세요. (에러 메시지, 발생 페이지, 재현 조건 등)"
-
-### 이슈 생성
-
-AI가 오류 설명을 기반으로 이슈를 생성합니다. **사용자 확인 없이 즉시 생성합니다** (긴급 상황).
-
-```bash
-gh issue create --title "hotfix: [오류 요약]" --body "[오류 상세]" --label "bug,hotfix"
-```
-
-> `hotfix` 라벨이 없으면 `bug` 라벨만 사용합니다. 라벨 생성 실패는 무시하고 진행합니다.
-
-출력에서 이슈 번호를 추출합니다 (예: `#207`).
 
 ---
 
 ## 2단계: hotfix 브랜치 생성
 
-이슈 제목에서 영문 슬러그를 생성합니다:
+오류 설명에서 영문 슬러그를 생성합니다:
 
 ```bash
-git checkout -b hotfix/[이슈번호]-[슬러그]
-git push -u origin hotfix/[이슈번호]-[슬러그]
+# Linear 이슈가 있는 경우
+git checkout -b hotfix/SPM-[번호]-[슬러그]
+git push -u origin hotfix/SPM-[번호]-[슬러그]
+
+# Linear 이슈가 없는 경우
+git checkout -b hotfix/urgent-[슬러그]
+git push -u origin hotfix/urgent-[슬러그]
 ```
 
 ---
@@ -146,7 +157,15 @@ npx tsc --noEmit
 
 ```bash
 git add [변경된 파일들]
-git commit -m "hotfix: [수정 내용 요약] (#이슈번호)
+# Linear 이슈가 있는 경우
+git commit -m "hotfix: [수정 내용 요약] (SPM-[번호])
+
+[상세 설명]
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# Linear 이슈가 없는 경우
+git commit -m "hotfix: [수정 내용 요약]
 
 [상세 설명]
 
@@ -164,7 +183,8 @@ git push
 ### PR 생성
 
 ```bash
-gh pr create --title "hotfix: [수정 요약]" --body "$(cat <<'EOF'
+# Linear 이슈가 있는 경우
+gh pr create --title "hotfix: [수정 요약] (SPM-[번호])" --body "$(cat <<'EOF'
 ## 🚨 Hotfix
 
 - **오류**: [오류 설명]
@@ -176,11 +196,13 @@ gh pr create --title "hotfix: [수정 요약]" --body "$(cat <<'EOF'
 - [x] `npm run test:run` 통과
 - [x] `npx tsc --noEmit` 통과
 
-Closes #[이슈번호]
+Linear: SPM-[번호]
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
+
+# Linear 이슈가 없는 경우 — PR 본문에서 Linear 라인 생략
 ```
 
 ### 자동 머지
@@ -196,25 +218,6 @@ gh pr merge --squash --auto --delete-branch
 > ⚠️ 자동 머지가 실패했습니다. 아래 명령어로 수동 머지해주세요:
 >   gh pr merge [PR번호] --squash --delete-branch
 > ```
-
-### 머지 후 이슈 클로즈 확인
-
-> **배경**: squash 머지 시 GitHub가 커밋 메시지를 재구성하면서 PR 본문의
-> `Closes #N` 키워드가 스쿼시된 커밋에 포함되지 않을 수 있다.
-> 이 경우 이슈가 자동 클로즈되지 않으므로 반드시 확인 후 수동 처리한다.
-
-머지 완료 후 연결된 이슈의 상태를 확인합니다:
-
-```bash
-gh issue view [이슈번호] --json state -q '.state'
-```
-
-- **CLOSED**: 정상 — 다음 단계 진행
-- **OPEN**: 자동 클로즈 실패 — 수동으로 닫는다:
-
-```bash
-gh issue close [이슈번호] --comment "PR #[PR번호] 머지로 작업 완료"
-```
 
 ---
 
@@ -238,9 +241,9 @@ git stash pop
 ```
 🚨 Hotfix 완료
 ─────────────────────────────
-📌 이슈: #[번호] [이슈 제목]
+📌 Linear 이슈: SPM-[번호] [오류 요약]  (또는 "이슈 미등록 — Linear에서 생성 필요")
 🔀 PR: #[PR번호] (머지 완료)
-🌿 브랜치: hotfix/[번호]-[슬러그] (삭제됨)
+🌿 브랜치: hotfix/SPM-[번호]-[슬러그] (삭제됨)
 ─────────────────────────────
 📝 변경 파일:
    - [파일1]
@@ -250,3 +253,10 @@ git stash pop
 ─────────────────────────────
 Render 자동 배포가 트리거됩니다.
 ```
+
+> Linear 이슈 없이 진행한 경우, 마지막에 아래 경고를 추가합니다:
+>
+> ```
+> ⚠️ Linear 이슈가 등록되지 않았습니다.
+>    팀원이 진행상황을 파악할 수 있도록 Linear에서 이슈를 생성해주세요.
+> ```

--- a/.claude/skills/spm-start/SKILL.md
+++ b/.claude/skills/spm-start/SKILL.md
@@ -2,7 +2,7 @@
 name: spm-start
 description: >
   Side Project Mate 작업 시작 커맨드.
-  `/spm-start [작업내용]` 형태로 호출하면 GitHub 이슈 생성, 브랜치 생성,
+  `/spm-start [SPM-번호] [작업내용]` 형태로 호출하면 Linear 이슈 기반 브랜치 생성,
   .workzones.yml 등록, 관련 MAP.md + 최근 work-logs 로딩을 한 번에 수행합니다.
   인자 없이 호출하면 대화형으로 작업 유형을 선택합니다.
   sideProjectMate 프로젝트에서 모든 작업 시작 시 항상 이 커맨드를 먼저 실행하세요.
@@ -10,17 +10,19 @@ description: >
 
 # spm-start — 작업 시작 커맨드
 
-이 스킬은 `/spm-start [작업내용]` 형태로 호출됩니다.
+이 스킬은 `/spm-start [SPM-번호] [작업내용]` 형태로 호출됩니다.
 인자 없이 `/spm-start`만 호출하면 대화형으로 진행합니다.
 
+> **이슈 관리**: 이슈는 **Linear**에서 생성·관리합니다 (팀 식별자: `SPM`).
+> 개발자는 Linear에서 이슈를 확인한 뒤, 이 커맨드로 작업을 시작합니다.
 > **워크존 역할 안내**: `.workzones.yml`은 팀 간 공유용이 아닌 **로컬 AI 컨텍스트 로딩 전용**입니다.
-> 팀원 간 작업 범위 파악은 GitHub 이슈 + 브랜치로 대체합니다.
+> 팀원 간 작업 범위 파악은 Linear 이슈 + 브랜치로 대체합니다.
 
 ---
 
 ## 0단계: GitHub CLI 인증 확인
 
-가장 먼저 `gh` CLI 인증 상태를 확인합니다:
+브랜치 push 및 PR 생성을 위해 `gh` CLI 인증 상태를 확인합니다:
 
 ```bash
 gh auth status
@@ -72,125 +74,179 @@ git rev-parse --abbrev-ref HEAD   # main/master가 아닌 경우
 ## 2단계: 작업 유형 선택
 
 `AskUserQuestion` 도구로 선택지를 제시합니다.
-인자가 있으면 내용을 분석해 적절한 유형을 추천 옵션(Recommended)으로 표시합니다.
 
 - question: "어떤 작업을 시작할까요?"
 - header: "작업 유형"
 - options:
-  - label: "신규 기능 개발 (Recommended)", description: "GitHub 이슈 생성 → feature/이슈번호 브랜치 생성"
-  - label: "버그 수정", description: "GitHub 이슈 생성(bug 라벨) → fix/이슈번호 브랜치 생성"
-  - label: "기존 이슈 이어받기", description: "오픈 이슈 목록에서 선택 → 기존 브랜치 checkout"
+  - label: "Linear 이슈로 새 작업 시작 (Recommended)", description: "Linear 이슈 ID를 입력 → 브랜치 생성"
+  - label: "새 Linear 이슈 생성 후 시작", description: "대화 내용을 기반으로 Linear 이슈를 생성하고 바로 작업을 시작합니다"
+  - label: "기존 브랜치 이어받기", description: "이미 생성된 SPM 브랜치에서 작업을 이어받습니다"
+
+인자가 `SPM-` 접두사로 시작하면 자동으로 "Linear 이슈로 새 작업 시작"을 선택하고 이슈 ID를 파싱합니다.
+(예: `/spm-start SPM-42 칸반보드 드래그앤드롭 개선`)
 
 ---
 
-### [1. feature 선택 시]
+### [1. Linear 이슈로 새 작업 시작]
 
-**a. 계획서 파일 확인**
+**a. Linear 이슈 ID 입력**
+
+인자에서 `SPM-` 접두사가 포함된 이슈 ID를 추출합니다.
+인자가 없거나 이슈 ID가 없으면 `AskUserQuestion` 도구로 입력을 요청합니다:
+
+- question: "Linear 이슈 ID를 입력해주세요 (예: SPM-42)"
+- header: "Linear 이슈"
+
+입력값에서 `SPM-[숫자]` 패턴을 추출합니다. 유효하지 않으면 다시 요청합니다.
+
+**b. 작업 내용 확인**
+
+인자에 이슈 ID 외 추가 텍스트가 있으면 이를 작업 내용(이슈 제목)으로 사용합니다.
+없으면 `AskUserQuestion` 도구로 작업 내용을 간략히 입력받습니다:
+
+- question: "이 이슈의 작업 내용을 한 줄로 요약해주세요 (브랜치명 슬러그 생성에 사용됩니다)"
+- header: "작업 내용"
+
+**c. 작업 유형 결정**
+
+`AskUserQuestion` 도구로 선택지를 제시합니다:
+
+- question: "작업 유형을 선택해주세요."
+- header: "브랜치 유형"
+- options:
+  - label: "기능 개발 (feature)", description: "feature/SPM-[번호]-[slug] 브랜치 생성"
+  - label: "버그 수정 (fix)", description: "fix/SPM-[번호]-[slug] 브랜치 생성"
+
+작업 내용에 "fix", "버그", "수정", "오류", "에러" 등이 포함되면 "버그 수정"을 Recommended로 표시합니다.
+그 외에는 "기능 개발"을 Recommended로 표시합니다.
+
+**d. 계획서 파일 확인 (기능 개발 시)**
 
 `AskUserQuestion` 도구로 선택지를 제시합니다:
 
 - question: "관련 계획서 파일이 docs/plans/에 있나요?"
 - header: "계획서"
 - options:
-  - label: "있음", description: "파일을 선택하면 AI가 읽고 이슈 초안을 작성합니다"
-  - label: "없음", description: "작업 내용을 직접 설명하면 AI가 이슈 초안을 작성합니다"
+  - label: "있음", description: "파일을 선택하면 AI가 읽고 컨텍스트를 로딩합니다"
+  - label: "없음 (Recommended)", description: "계획서 없이 진행합니다"
 
 **있음** 선택 시: `docs/plans/` 파일 목록을 보여주고 선택받습니다 (AskUserQuestion, 최대 4개, 초과 시 번호 직접 입력).
-**없음** 선택 시: 작업 내용을 자연어로 받아 이슈 초안 작성.
 
-AI가 이슈 초안을 작성한 뒤 `AskUserQuestion` 도구로 확인을 요청합니다:
+**e. 브랜치 생성 및 checkout**
 
-- question: "이슈 초안을 확인해주세요.\n제목: [이슈 제목]\n라벨: enhancement"
-- header: "이슈 확인"
-- options:
-  - label: "이대로 생성 (Recommended)", description: "초안 내용으로 GitHub 이슈를 생성합니다"
-  - label: "수정 후 생성", description: "Other를 선택해 수정할 내용을 입력하세요"
-
-확인 후 이슈 생성:
+작업 내용에서 영문 슬러그를 생성합니다 (예: "칸반보드 드래그앤드롭 개선" → `kanban-drag-drop`):
 
 ```bash
-gh issue create --title "[제목]" --body "[본문]" --label "enhancement"
-```
+# feature 선택 시
+git checkout -b feature/SPM-[번호]-[슬러그]
+git push -u origin feature/SPM-[번호]-[슬러그]
 
-출력에서 이슈 번호를 추출합니다 (예: `#180`).
-
-**b. 브랜치 생성 및 checkout**
-
-이슈 제목에서 영문 슬러그를 생성합니다 (예: "칸반보드 개선" → `kanban-improve`):
-
-```bash
-git checkout -b feature/[이슈번호]-[슬러그]
-git push -u origin feature/[이슈번호]-[슬러그]
+# fix 선택 시
+git checkout -b fix/SPM-[번호]-[슬러그]
+git push -u origin fix/SPM-[번호]-[슬러그]
 ```
 
 ---
 
-### [2. fix 선택 시]
+### [2. 새 Linear 이슈 생성 후 시작]
 
-버그 내용을 한 줄로 입력받습니다.
+대화 내용을 기반으로 Linear 이슈를 직접 생성하고, 바로 작업을 시작합니다.
 
-AI가 이슈 초안 작성 후 `AskUserQuestion` 도구로 확인을 요청합니다:
+**a. 작업 내용 입력**
 
-- question: "이슈 초안을 확인해주세요.\n제목: fix: [버그 내용]\n라벨: bug"
+인자에 작업 내용이 있으면 사용하고, 없으면 `AskUserQuestion` 도구로 입력받습니다:
+
+- question: "생성할 이슈의 작업 내용을 설명해주세요."
+- header: "새 이슈"
+
+**b. 작업 유형 결정**
+
+`AskUserQuestion` 도구로 선택지를 제시합니다:
+
+- question: "작업 유형을 선택해주세요."
+- header: "브랜치 유형"
+- options:
+  - label: "기능 개발 (feature)", description: "feature/SPM-[번호]-[slug] 브랜치 생성"
+  - label: "버그 수정 (fix)", description: "fix/SPM-[번호]-[slug] 브랜치 생성"
+
+작업 내용에 "fix", "버그", "수정", "오류", "에러" 등이 포함되면 "버그 수정"을 Recommended로 표시합니다.
+그 외에는 "기능 개발"을 Recommended로 표시합니다.
+
+**c. 이슈 초안 작성 및 확인**
+
+AI가 작업 내용을 분석하여 이슈 제목과 본문 초안을 작성합니다.
+`AskUserQuestion` 도구로 확인을 요청합니다:
+
+- question: "Linear 이슈 초안을 확인해주세요.\n제목: [이슈 제목]"
 - header: "이슈 확인"
 - options:
-  - label: "이대로 생성 (Recommended)", description: "초안 내용으로 GitHub 이슈를 생성합니다"
+  - label: "이대로 생성 (Recommended)", description: "Linear에 이슈를 생성합니다"
   - label: "수정 후 생성", description: "Other를 선택해 수정할 내용을 입력하세요"
+- preview 활용: 이슈 본문 전체를 preview 필드에 표시
 
-확인 후 이슈 생성:
+**d. Linear MCP로 이슈 생성**
+
+`mcp__claude_ai_Linear__save_issue` 도구로 이슈를 생성합니다:
+
+- team: "Sideprojectmate"
+- title: [확정된 이슈 제목]
+- description: [확정된 이슈 본문 (Markdown)]
+- labels: 버그 수정 시 ["Bug"], 기능 개발 시 ["Feature"] (라벨이 존재하는 경우)
+- assignee: "me"
+- priority: 3 (Normal, 사용자가 별도 지정하지 않은 경우)
+
+응답에서 이슈 ID(`SPM-[번호]`)를 추출합니다.
+
+**e. 브랜치 생성 및 checkout**
+
+이슈 제목에서 영문 슬러그를 생성합니다:
 
 ```bash
-gh issue create --title "fix: [버그 내용]" --body "[버그 상세 설명]" --label "bug"
+# feature 선택 시
+git checkout -b feature/SPM-[번호]-[슬러그]
+git push -u origin feature/SPM-[번호]-[슬러그]
+
+# fix 선택 시
+git checkout -b fix/SPM-[번호]-[슬러그]
+git push -u origin fix/SPM-[번호]-[슬러그]
 ```
 
-브랜치 생성:
-
-```bash
-git checkout -b fix/[이슈번호]-[슬러그]
-git push -u origin fix/[이슈번호]-[슬러그]
-```
+이후 3단계(도메인 감지)부터는 [1. Linear 이슈로 새 작업 시작]과 동일하게 진행합니다.
 
 ---
 
-### [3. 기존 이슈 이어받기 선택 시]
+### [3. 기존 브랜치 이어받기]
 
-오픈 이슈 목록 조회:
-
-```bash
-gh issue list --state open --json number,title,assignees --limit 20
-```
-
-목록을 표시하고 번호 선택을 받습니다:
-
-```
-오픈 이슈 목록:
-#182 칸반 성능 개선 (담당자: 없음)
-#181 채팅 알림 버그 (담당자: kimis)
-#180 SPM 스킬 개선 (담당자: caant)
-
-이어받을 이슈 번호를 입력하세요:
-```
-
-선택한 이슈의 기존 브랜치가 있으면 checkout, 없으면 새로 생성:
+원격 브랜치 중 `SPM-` 패턴이 포함된 브랜치를 조회합니다:
 
 ```bash
-# 기존 브랜치 확인
-gh issue view [번호] --json headRefName
+git fetch origin
+git branch -r --list "origin/feature/SPM-*" --list "origin/fix/SPM-*"
+```
 
-# 있으면
+목록을 표시하고 `AskUserQuestion`으로 선택을 받습니다:
+
+```
+이어받을 브랜치를 선택하세요:
+1. feature/SPM-42-kanban-drag-drop
+2. fix/SPM-38-chat-notification-bug
+3. feature/SPM-35-dashboard-widget
+```
+
+선택한 브랜치를 checkout합니다:
+
+```bash
 git checkout [브랜치명]
 git pull
-
-# 없으면
-git checkout -b feature/[이슈번호]-[슬러그]
-git push -u origin feature/[이슈번호]-[슬러그]
 ```
+
+브랜치명에서 `SPM-[번호]`를 추출하여 이후 단계에서 사용합니다.
 
 ---
 
 ## 3단계: 도메인 감지 및 파일 경로 매핑
 
-이슈 제목/내용 또는 인자에서 키워드를 감지해 관련 파일 경로를 결정합니다.
+이슈 작업 내용 또는 인자에서 키워드를 감지해 관련 파일 경로를 결정합니다.
 
 | 키워드                                | 잠금 경로                                                                 | 읽을 MAP.md                   |
 | ------------------------------------- | ------------------------------------------------------------------------- | ----------------------------- |
@@ -210,15 +266,19 @@ git push -u origin feature/[이슈번호]-[슬러그]
 
 ## 4단계: 팀원 충돌 감지
 
-내 작업 도메인 키워드로 오픈 이슈를 필터링합니다 (이미 조회한 목록 재활용):
+원격 브랜치 중 같은 도메인 키워드를 포함하고 현재 활성 상태인 브랜치가 있는지 확인합니다:
 
-- 같은 도메인 키워드를 포함한 이슈가 있고, 담당자가 있으면 한 줄 경고 출력:
-
-```
-⚠️ 주의: [담당자]가 이슈 #[번호] ([이슈 제목])로 같은 도메인 작업 중입니다.
+```bash
+git branch -r --list "origin/feature/SPM-*" --list "origin/fix/SPM-*"
 ```
 
-- 없으면 이 줄은 생략합니다.
+같은 도메인 키워드를 포함한 다른 팀원의 활성 브랜치가 있으면 한 줄 경고 출력:
+
+```
+⚠️ 주의: 브랜치 [브랜치명]이 같은 도메인에서 작업 중입니다.
+```
+
+없으면 이 줄은 생략합니다.
 
 ---
 
@@ -235,7 +295,7 @@ git push -u origin feature/[이슈번호]-[슬러그]
 - path: '감지된/경로'
   owner: '작업자이름'
   status: 'active'
-  reason: '이슈 제목 또는 사용자가 입력한 작업내용'
+  reason: 'SPM-[번호] 작업 내용'
   expires: 'YYYY-MM-DD'
 ```
 
@@ -246,7 +306,7 @@ git push -u origin feature/[이슈번호]-[슬러그]
 `CLAUDE.md`의 "현재 진행 중인 작업 현황" 표에서 해당 작업자의 기존 행을 교체하거나, 없으면 새로 추가합니다.
 
 ```markdown
-| src/app/api/kanban/ | [작업자] | 🟡 작업 중 | [이슈 제목] |
+| src/app/api/kanban/ | [작업자] | 🟡 작업 중 | SPM-[번호] [작업 내용] |
 ```
 
 "현재 작업 중인 항목 없음" 행은 실제 항목이 추가되면 제거합니다.
@@ -269,7 +329,7 @@ git push -u origin feature/[이슈번호]-[슬러그]
 ```
 ✅ SPM 세션 시작
 ─────────────────────────────
-📌 이슈: #[번호] [이슈 제목]
+📌 Linear 이슈: SPM-[번호] [작업 내용]
 👤 작업자: [이름]
 🌿 브랜치: [브랜치명]
 📁 잠금 구역:


### PR DESCRIPTION
## Summary

- **spm-start**: GitHub 이슈 생성 제거 → Linear 이슈 ID 입력 또는 Linear MCP로 직접 생성 (3가지 옵션)
- **spm-done**: 커밋 메시지와 PR에 `SPM-###` 포함하여 Linear ↔ GitHub 자동 연동
- **spm-commit**: 커밋 메시지 제목에 `(SPM-###)` 포함
- **spm-hotfix**: `gh issue create/close` 제거 → Linear 이슈 ID 기반으로 변경

## 배경

비개발자(사업/기획) 팀원 합류 예정으로, 전체 이슈와 진행상황을 Linear 보드에서 한눈에 파악할 수 있도록 GitHub Issues → Linear 완전 이전.

## 브랜치 명명규칙 변경

- Before: `feature/180-kanban-improve`
- After: `feature/SPM-42-kanban-improve`

## Test plan

- [ ] `/spm-start SPM-5 테스트` 실행하여 Linear 이슈 ID 파싱 확인
- [ ] `/spm-commit` 실행 시 커밋 메시지에 `(SPM-5)` 포함 확인
- [ ] Linear 보드에서 브랜치/커밋 자동 연동 확인

Linear: SPM-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)