### PR TITLE
feat: 쿨타임 에러 알림을 공통 토스트 팝업으로 변경 (SPM-7)

### DIFF
--- a/src/store/instructionStore.ts
+++ b/src/store/instructionStore.ts
@@ -2,6 +2,7 @@
 
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
+import { useToastStore } from '@/components/common/Toast';
 
 /* ── 타입 ── */
 interface TargetScope {
@@ -133,7 +134,12 @@ export const useInstructionStore = create<InstructionState & InstructionActions>
           // 비스트리밍 에러 처리
           if (!res.ok && res.headers.get('content-type')?.includes('application/json')) {
             const json = await res.json();
-            set({ isGenerating: false, error: json.message });
+            if (res.status === 429) {
+              useToastStore.getState().show(json.message, 'error');
+              set({ isGenerating: false });
+            } else {
+              set({ isGenerating: false, error: json.message });
+            }
             return;
           }
 


### PR DESCRIPTION
## Summary
- 지시서 생성 시 쿨타임 미충족(429) 에러를 모달 내 인라인 에러 박스 대신 공통 토스트 팝업(useToastStore)으로 표시하도록 변경
- 쿨타임 외 다른 에러(401, 400 등)는 기존 인라인 표시 유지

## Test plan
- [x] npm run test:run 556 passed / 0 failed
- [x] npx tsc --noEmit 통과
- [ ] 테스트 서버에서 쿨타임 내 지시서 재생성 시 토스트 팝업 확인

Linear: SPM-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)