### PR TITLE
fix: 하네스 추천 매칭 실패 — target 타입별 노트 조회 추가 (SPM-8)

### DIFF
--- a/src/app/api/ai/recommend-harness/route.ts
+++ b/src/app/api/ai/recommend-harness/route.ts
@@ -10,6 +10,12 @@ import { recommendHarness } from '@/lib/utils/ai/recommendHarness';
 
 export const dynamic = 'force-dynamic';
 
+interface TargetScope {
+  type: 'all' | 'sections' | 'notes';
+  sectionIds?: string[];
+  noteIds?: string[];
+}
+
 // POST /api/ai/recommend-harness — 프로젝트/노트 기반 하네스 추천
 async function handlePost(request: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -20,10 +26,10 @@ async function handlePost(request: NextRequest) {
   await dbConnect();
 
   const body = await request.json();
-  const { boardId, presetName, targetNoteIds } = body as {
+  const { boardId, presetName, target } = body as {
     boardId: string;
     presetName?: string;
-    targetNoteIds?: string[];
+    target?: TargetScope;
   };
 
   if (!boardId) {
@@ -48,12 +54,27 @@ async function handlePost(request: NextRequest) {
     techStacks: string[];
   } | null;
 
-  // 대상 노트 텍스트 수집
+  // 대상 노트 텍스트 수집 — target 타입별로 generate-instruction과 동일하게 조회
   let targetNoteTexts: string[] = [];
-  if (targetNoteIds && targetNoteIds.length > 0) {
-    const notes = (await Note.find({ _id: { $in: targetNoteIds } })
+  const targetType = target?.type || 'all';
+
+  if (targetType === 'notes' && target?.noteIds?.length) {
+    const notes = (await Note.find({ _id: { $in: target.noteIds } })
       .select('text')
       .lean()) as unknown as Array<{ text: string }>;
+    targetNoteTexts = notes.map((n) => n.text);
+  } else if (targetType === 'sections' && target?.sectionIds?.length) {
+    const notes = (await Note.find(
+      { sectionId: { $in: target.sectionIds }, boardId, status: 'active' },
+      { text: 1 }
+    ).lean()) as unknown as Array<{ text: string }>;
+    targetNoteTexts = notes.map((n) => n.text);
+  } else {
+    // all 또는 target 미지정 시 보드 전체 active 노트 조회
+    const notes = (await Note.find(
+      { boardId, status: 'active' },
+      { text: 1 }
+    ).lean()) as unknown as Array<{ text: string }>;
     targetNoteTexts = notes.map((n) => n.text);
   }
 

--- a/src/store/instructionStore.ts
+++ b/src/store/instructionStore.ts
@@ -225,7 +225,7 @@ export const useInstructionStore = create<InstructionState & InstructionActions>
             body: JSON.stringify({
               boardId,
               presetName: get().preset,
-              targetNoteIds: target.noteIds || [],
+              target,
             }),
           });
 


### PR DESCRIPTION
## Summary
- recommend-harness API가 target 타입(all/sections/notes)을 처리하지 않아 노트 텍스트 없이 techStacks만으로 검색하던 문제 수정
- instructionStore에서 target 객체 전체를 API에 전달하도록 변경
- API에서 generate-instruction과 동일한 target.type별 노트 조회 로직 추가

## Test plan
- [x] npm run test:run 556 passed / 0 failed
- [x] npx tsc --noEmit 통과
- [ ] 테스트 서버에서 지시서 생성 후 하네스 추천 패널에 결과 표시 확인

Linear: SPM-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)