### PR TITLE
fix: 쿨타임 토스트 미표시 — z-index 수정 + 429 체크 순서 변경 (SPM-7)

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -101,7 +101,7 @@ export default function Toast() {
 
   return (
     <div
-      className="fixed z-[200] flex flex-col gap-2 w-[420px] max-w-[calc(100vw-2rem)] bottom-20 left-1/2 -translate-x-1/2 md:bottom-auto md:top-20 md:left-1/2 md:-translate-x-1/2"
+      className="fixed z-[10000] flex flex-col gap-2 w-[420px] max-w-[calc(100vw-2rem)] bottom-20 left-1/2 -translate-x-1/2 md:bottom-auto md:top-20 md:left-1/2 md:-translate-x-1/2"
       aria-live="polite"
       aria-atomic="false"
     >

--- a/src/store/instructionStore.ts
+++ b/src/store/instructionStore.ts
@@ -131,15 +131,22 @@ export const useInstructionStore = create<InstructionState & InstructionActions>
             }),
           });
 
+          // 쿨타임/한도 초과 (429) — content-type 무관하게 토스트로 표시
+          if (res.status === 429) {
+            try {
+              const json = await res.json();
+              useToastStore.getState().show(json.message, 'error');
+            } catch {
+              useToastStore.getState().show('잠시 후 다시 시도해주세요.', 'error');
+            }
+            set({ isGenerating: false });
+            return;
+          }
+
           // 비스트리밍 에러 처리
           if (!res.ok && res.headers.get('content-type')?.includes('application/json')) {
             const json = await res.json();
-            if (res.status === 429) {
-              useToastStore.getState().show(json.message, 'error');
-              set({ isGenerating: false });
-            } else {
-              set({ isGenerating: false, error: json.message });
-            }
+            set({ isGenerating: false, error: json.message });
             return;
           }
 


### PR DESCRIPTION
## Summary
- Toast z-index 200 → 10000으로 변경 (InstructionModal z-[9999] 위에 표시)
- 429 상태코드 체크를 content-type 체크보다 앞에 배치하여 배포 환경에서도 안정적으로 동작
- JSON 파싱 실패 시 fallback 메시지 표시

## Root cause
v1에서 content-type 헤더 체크 내부에 429 분기가 중첩되어, 헤더 불일치 시 429가 SSE 스트리밍 경로로 빠짐. 추가로 Toast z-index(200)가 모달(9999)보다 낮아 토스트가 가려짐.

## Test plan
- [x] npm run test:run 556 passed / 0 failed
- [x] npx tsc --noEmit 통과
- [ ] 테스트 서버에서 쿨타임 내 지시서 생성 시 토스트 팝업 확인

Linear: SPM-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)