### PR TITLE
fix: 사이드바 광고배너 SPA 라우팅 시 미노출 수정 (SPM-16)

### DIFF
--- a/src/components/common/AdBanner.tsx
+++ b/src/components/common/AdBanner.tsx
@@ -64,19 +64,34 @@ export default function AdBanner({
   useEffect(() => {
     if (!shouldShow) return;
 
-    // 기존 스크립트 제거 → 재주입하여 SDK가 현재 DOM의 ins 태그를 재스캔
-    document.getElementById(ADFIT_SCRIPT_ID)?.remove();
+    // AdFit SDK 로드 후 ins 태그를 초기화
+    // 스크립트가 이미 있으면 재주입하지 않고, SDK의 adfit() 함수로 직접 초기화
+    const existingScript = document.getElementById(ADFIT_SCRIPT_ID);
 
+    const initAd = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (typeof (window as any).adfit === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).adfit();
+      }
+    };
+
+    if (existingScript) {
+      // SDK 이미 로드됨 — 약간의 딜레이 후 재초기화 (ins 태그가 DOM에 마운트된 후)
+      const timer = setTimeout(initAd, 100);
+      return () => clearTimeout(timer);
+    }
+
+    // SDK 최초 로드
     const script = document.createElement('script');
     script.id = ADFIT_SCRIPT_ID;
     script.type = 'text/javascript';
     script.src = ADFIT_SCRIPT_SRC;
     script.async = true;
+    script.onload = initAd;
     document.head.appendChild(script);
 
-    return () => {
-      document.getElementById(ADFIT_SCRIPT_ID)?.remove();
-    };
+    // cleanup에서 스크립트를 제거하지 않음 — 다른 AdBanner 인스턴스가 공유
   }, [shouldShow, resolvedUnitId, width, height]);
 
   if (!shouldShow) {

--- a/work-logs/2026-04-12-FFLINA-PC-9b8b072.md
+++ b/work-logs/2026-04-12-FFLINA-PC-9b8b072.md
@@ -1,0 +1,30 @@
+## 2026-04-12 — FFLINA-PC (fix/SPM-16-sidebar-ad-banner) `9b8b072`
+
+> 모델: claude (spm-done 자동생성)
+
+## 작업 요약
+
+프로젝트 리스트 사이드바 광고배너 미노출 수정 — AdFit SDK 스크립트 재주입 방식을 공유+adfit() 직접 호출로 변경하여 SPA 라우팅 시 광고 사라짐 해결
+
+## 변경된 파일
+
+### 수정
+- `src/components/common/AdBanner.tsx` — SDK 스크립트 제거/재주입 → 공유+`window.adfit()` 직접 호출 방식으로 변경, cleanup에서 스크립트 제거 제거
+
+## 테스트 결과
+
+- 실행 명령: `npm run test:run`
+- 결과: 567 passed / 0 failed
+- 신규 추가 테스트: 0개
+- 미작성 테스트 및 사유: AdBanner는 외부 SDK(카카오 AdFit) 의존 컴포넌트로, 실제 광고 로드는 운영서버에서만 확인 가능. DOM 렌더링은 기존 테스트에서 커버됨.
+
+## 건드리면 안 되는 부분
+
+| 파일 | 위치 | 이유 |
+|------|------|------|
+| AdBanner.tsx | SDK 스크립트 공유 패턴 (cleanup에서 제거 안 함) | 여러 AdBanner 인스턴스가 동일 SDK 스크립트를 공유 — cleanup에서 제거하면 다른 배너가 사라짐 |
+| AdBanner.tsx | `window.adfit()` 호출 + 100ms 딜레이 | SPA 라우팅 시 ins 태그가 DOM에 마운트된 후 SDK가 인식하도록 하는 타이밍 — 제거 시 광고 미로드 |
+
+## 미완성 / 다음 세션에서 이어받을 부분
+
+- 운영서버 배포 후 광고 정상 노출 확인 필요


### PR DESCRIPTION
## Summary

- 프로젝트 리스트 사이드바 광고배너가 SPA 라우팅 시 잠깐 보였다 사라지는 현상 수정
- AdFit SDK 스크립트 제거/재주입 패턴 → 공유 + `window.adfit()` 직접 호출로 변경

## Changes

- `src/components/common/AdBanner.tsx` — SDK 공유 + adfit() 재초기화 방식으로 변경

## Test plan

- [x] `npm run test:run` — 567 passed / 0 failed
- [x] `npx tsc --noEmit` — 타입 체크 통과
- [ ] 운영서버 배포 후 프로젝트 리스트 사이드바 광고 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: SPM-16